### PR TITLE
Fix abi and xtask tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 name = "abi"
 version = "0.1.0"
 dependencies = [
+ "abi",
  "abi-macros",
  "blake3",
  "serde",

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -10,3 +10,6 @@ abi-macros = { version = "0.1.0", path = "../abi-macros" }
 
 [features]
 kernel-id-gen = []
+
+[dev-dependencies]
+abi = { path = ".", features = ["kernel-id-gen"] }

--- a/abi/src/drawlist.rs
+++ b/abi/src/drawlist.rs
@@ -425,6 +425,14 @@ mod tests {
         let verbs = [PathVerb::MoveTo(PointF::new(0.0, 0.0))];
         builder.push_fill_path(&verbs, FillRule::NonZero, 0xff00ff00);
         let mut bytes = builder.finish();
+
+        // Tamper with the command length to include the extra byte
+        // Header (16) + Tag (4) = 20
+        let len_offset = 20;
+        let mut len = u32::from_le_bytes(bytes[len_offset..len_offset + 4].try_into().unwrap());
+        len += 1;
+        bytes[len_offset..len_offset + 4].copy_from_slice(&len.to_le_bytes());
+
         bytes.push(0);
         let mut reader = DrawListReader::new(&bytes).expect("reader");
         let cmd = reader.next().expect("cmd");

--- a/xtask/src/common.rs
+++ b/xtask/src/common.rs
@@ -58,6 +58,7 @@ mod tests {
     #[test]
     fn project_root_ends_with_repo_name() {
         let root = project_root();
-        assert!(root.ends_with("thing-os"));
+        // Check that the root directory contains the main Cargo.toml
+        assert!(root.join("Cargo.toml").exists());
     }
 }


### PR DESCRIPTION
Fix broken/failing tests in `abi` and `xtask` crates to ensure `just test` passes cleanly.

*   Modified `abi/Cargo.toml` to add `[dev-dependencies]` enabling `kernel-id-gen` for the `abi` crate itself. This exposes `ThingId::new_debug_nonce` for integration tests.
*   Fixed `fill_path_rejects_trailing_bytes` unit test in `abi/src/drawlist.rs`. The test was incorrectly appending bytes outside the command frame, which were ignored by the reader. The fix manually updates the command length to include the trailing byte, ensuring the payload decoder receives it and rejects it.
*   Fixed `project_root_ends_with_repo_name` unit test in `xtask/src/common.rs` to rely on `Cargo.toml` presence rather than the directory name, supporting arbitrary checkout directories (like `/app` in CI).

---
*PR created automatically by Jules for task [16223404127118632841](https://jules.google.com/task/16223404127118632841) started by @dancxjo*