### PR TITLE
⚖️ Steward: Reduce allocations in watch handler hot path

### DIFF
--- a/.jules/steward.md
+++ b/.jules/steward.md
@@ -1,1 +1,2 @@
 2026-01-18 – [Logging Allocations] Learning: Logging in the kernel was allocating multiple Strings per event, putting pressure on the allocator in hot paths. Guardrail: Use `SymbolShell::Static` and `&'static str` for metadata that is known to be static.
+2026-01-27 – [Watch Allocations] Learning: The watch notification loop in `handle_watch_next` was allocating vectors for every filtered commit, even if discarded. Guardrail: Use reusable buffers (passed down from the handler) for operations that run in a loop, especially for transient data like filtered payloads.

--- a/kernel/src/root/handlers/watch.rs
+++ b/kernel/src/root/handlers/watch.rs
@@ -5,7 +5,7 @@
 //! Watches may filter commits by subject/predicate/kind using O(1) summary matching.
 
 use crate::root::graph::{Graph, GlobalWatch, WatchFilter, WATCH_SCAN_LIMIT, commit_matches};
-use crate::root::handlers::watch_payload::filter_watch_payload;
+use crate::root::handlers::watch_payload::{filter_watch_payload, CoalesceEntry};
 use crate::root::resources::{stream, ResourceHandle};
 use crate::root::symbols::Interner;
 use crate::root::query::PreparedStep;
@@ -143,6 +143,8 @@ pub fn handle_watch_next(
     
     // 3. Bounded scan for matching commit
     let mut scanned = 0usize;
+    let mut out_buf = alloc::vec::Vec::new();
+    let mut coalesce_buf: alloc::vec::Vec<CoalesceEntry> = alloc::vec::Vec::new();
 
     while scanned < WATCH_SCAN_LIMIT {
         // Cursor ahead of newest: no new commits yet
@@ -179,23 +181,23 @@ pub fn handle_watch_next(
             None => return (-75, 0), // Shouldn't happen, treat as overflow
         };
 
-        let filtered = if filter.matches_all() {
-            None
+        out_buf.clear();
+        coalesce_buf.clear();
+
+        let payload = if filter.matches_all() {
+            data
         } else {
-            match filter_watch_payload(data, &filter) {
-                Ok(bytes) => Some(bytes),
+            match filter_watch_payload(data, &filter, &mut out_buf, &mut coalesce_buf) {
+                Ok(()) => {
+                    if out_buf.is_empty() {
+                        cursor += 1;
+                        scanned += 1;
+                        continue;
+                    }
+                    out_buf.as_slice()
+                }
                 Err(_) => return (-22, 0),
             }
-        };
-
-        let payload = match filtered.as_ref() {
-            Some(bytes) if bytes.is_empty() => {
-                cursor += 1;
-                scanned += 1;
-                continue;
-            }
-            Some(bytes) => bytes.as_slice(),
-            None => data,
         };
 
         if (out_len as usize) < payload.len() {

--- a/kernel/src/root/handlers/watch_payload.rs
+++ b/kernel/src/root/handlers/watch_payload.rs
@@ -143,7 +143,7 @@ pub fn track_watch_encode_reject(reason: WatchEncodeRejectReason) {
     log_watch_encode_reject_once(reason);
 }
 
-struct CoalesceEntry {
+pub(crate) struct CoalesceEntry {
     subject: WireThingId,
     predicate: PredicateId,
     encoding: u8,
@@ -184,13 +184,13 @@ fn event_matches_filter(
     true
 }
 
-pub fn filter_watch_payload(
+pub(crate) fn filter_watch_payload(
     payload: &[u8],
     filter: &WatchFilter,
-) -> Result<Vec<u8>, DecodeError> {
+    out: &mut Vec<u8>,
+    coalesce: &mut Vec<CoalesceEntry>,
+) -> Result<(), DecodeError> {
     let mut cursor = 0usize;
-    let mut out = Vec::new();
-    let mut coalesce: Vec<CoalesceEntry> = Vec::new();
 
     while cursor < payload.len() {
         let event_start = cursor;
@@ -224,5 +224,5 @@ pub fn filter_watch_payload(
         });
     }
 
-    Ok(out)
+    Ok(())
 }


### PR DESCRIPTION
Refactored `filter_watch_payload` to accept caller-allocated buffers and updated `handle_watch_next` to reuse these buffers across the scan loop to reduce allocator pressure.

---
*PR created automatically by Jules for task [13852729742581403291](https://jules.google.com/task/13852729742581403291) started by @dancxjo*