### PR TITLE
Fix inconsistent content provider schema definitions

### DIFF
--- a/abi/src/schema.rs
+++ b/abi/src/schema.rs
@@ -498,9 +498,9 @@ pub mod kinds {
     /// A content source that provides files/directories (Limine modules, ISO, etc.)
     pub const CONTENT_SOURCE: &str = "content.Source";
     /// A directory in the filesystem graph
-    pub const CONTENT_DIR: &str = "fs.Directory";
+    pub const CONTENT_DIR: &str = "content.Directory";
     /// A file in the filesystem graph
-    pub const CONTENT_FILE: &str = "fs.File";
+    pub const CONTENT_FILE: &str = "content.File";
 }
 
 /// Snapshot semantics and constants for UI presentation surfaces.


### PR DESCRIPTION
Align `CONTENT_DIR` and `CONTENT_FILE` schema definitions with `test_content_kinds_exist` expectations by renaming them to `content.Directory` and `content.File` respectively. This enforces consistency within the Content Provider System schema.

---
*PR created automatically by Jules for task [14009873217097246174](https://jules.google.com/task/14009873217097246174) started by @dancxjo*