### PR TITLE
Fix display slant by trusting bootloader stride

### DIFF
--- a/bran/src/framebuffer.rs
+++ b/bran/src/framebuffer.rs
@@ -46,7 +46,7 @@ impl bud::framebuffer::FramebufferTarget for Framebuffer {
         // Ensure stride is at least width * 4 (32bpp)
         // This handles cases where bootloader might report 0 or invalid pitch
         let min_stride = self.width * 4;
-        let stride = if self.pitch >= min_stride {
+        let stride = if self.pitch > 0 {
             self.pitch
         } else {
             min_stride

--- a/bud/src/display.rs
+++ b/bud/src/display.rs
@@ -335,7 +335,7 @@ impl<'a, F: FramebufferTarget> FbDrawer<'a, F> {
             PixelFormat::Rgb888 | PixelFormat::Bgr888 => info.width * 3,
             _ => info.width,
         };
-        let stride = if info.stride < min_stride { min_stride } else { info.stride };
+        let stride = if info.stride > 0 { info.stride } else { min_stride };
 
         let offset = (point.y as usize * stride as usize) + (point.x as usize * bpp);
         if offset + bpp > buffer.len() {


### PR DESCRIPTION
The display was slanting (shearing) because 'bran' and 'bud' were enforcing a minimum stride of 'width * 4', which ignored the actual hardware pitch if it was slightly smaller (e.g. if 'width' was slightly larger than the pitch implies). This change trusts the 'pitch' reported by Limine as long as it is non-zero.

---
*PR created automatically by Jules for task [12521894288379288123](https://jules.google.com/task/12521894288379288123) started by @dancxjo*