### PR TITLE
⚖️ Steward: Introduce Root registry links

### DIFF
--- a/abi/src/schema.rs
+++ b/abi/src/schema.rs
@@ -675,6 +675,8 @@ pub mod rels {
     pub const HAS_CPU: &str = "HAS_CPU";
     pub const HAS_MEMORY_RANGE: &str = "HAS_MEMORY_RANGE";
     pub const HAS_MODULE: &str = "HAS_MODULE";
+    pub const HAS_SERVICE: &str = "HAS_SERVICE";
+    pub const MONITORS: &str = "MONITORS";
     pub const SEEDED_BY: &str = "SEEDED_BY";
     pub const USES: &str = "USES";
     // LPC / Legacy IO

--- a/kernel/src/root/boot_register.rs
+++ b/kernel/src/root/boot_register.rs
@@ -162,6 +162,7 @@ pub fn register_all<R: crate::BootRuntime>(runtime: &R, info: &BootInfo) -> Boot
     let root_name = intern("/");
     set(root_svc, keys::NAME, root_name);
     link(kernel, rels::PROVIDES, root_svc);
+    link(root_svc, rels::MONITORS, host);
 
     // 5. CPUs
     for i in 0..info.cpu_count {
@@ -232,6 +233,7 @@ pub fn register_all<R: crate::BootRuntime>(runtime: &R, info: &BootInfo) -> Boot
         set(mod_node, keys::CONFIDENCE, conf_high);
 
         link(host, rels::HAS_MODULE, mod_node);
+        link(root_svc, rels::HAS_MODULE, mod_node);
     }
 
     // 8. Framebuffer
@@ -359,6 +361,7 @@ pub fn register_all<R: crate::BootRuntime>(runtime: &R, info: &BootInfo) -> Boot
     // 10. Tasking
     let scheduler = create(kinds::SVC_SCHEDULER);
     link(kernel, rels::PROVIDES, scheduler);
+    link(root_svc, rels::HAS_SERVICE, scheduler);
     
     // Store well-known ThingIds for scheduler graphification
     super::graph_anchors::set_scheduler_service(scheduler);


### PR DESCRIPTION
This change establishes `svc.Root` as a central registry by explicitly linking it to the Scheduler, Host hardware root, and Boot Modules during boot registration.

Previously, finding these components required linear scans (`RootOp::Find`) of the entire graph or specific Kinds. By creating direct edges from the Root service, clients can now discover them via O(1) graph traversal (Expand operations).

This aligns with The Steward's mission to replace graph scans with explicit links, improving inspectability and performance.

Verification:
- Kernel builds and passes unit tests (`cargo test --lib --package kernel`).
- Verified `abi` schema changes compile.
- Verified `svc.Root` connectivity logic in `boot_register.rs`.

---
*PR created automatically by Jules for task [479967363530870814](https://jules.google.com/task/479967363530870814) started by @dancxjo*