### PR TITLE
Fix content provider schema mismatch in tests and docs

### DIFF
--- a/abi/tests/content_provider_schema.rs
+++ b/abi/tests/content_provider_schema.rs
@@ -19,8 +19,8 @@ fn test_content_source_states() {
 fn test_content_kinds_exist() {
     // Ensure content provider kinds are defined
     assert_eq!(kinds::CONTENT_SOURCE, "content.Source");
-    assert_eq!(kinds::CONTENT_DIR, "content.Directory");
-    assert_eq!(kinds::CONTENT_FILE, "content.File");
+    assert_eq!(kinds::CONTENT_DIR, "fs.Directory");
+    assert_eq!(kinds::CONTENT_FILE, "fs.File");
 }
 
 #[test]

--- a/docs/CONTENT_PROVIDER.md
+++ b/docs/CONTENT_PROVIDER.md
@@ -37,7 +37,7 @@ Represents a source of content (Limine boot modules, ISO9660 disk, future: netwo
 
 #### File Nodes
 
-**Kind**: `content.File`
+**Kind**: `fs.File`
 
 Represents a file from any content source.
 
@@ -51,7 +51,7 @@ Represents a file from any content source.
 
 #### Directory Nodes
 
-**Kind**: `content.Directory`
+**Kind**: `fs.Directory`
 
 Represents a directory in the content graph (future enhancement).
 
@@ -74,7 +74,7 @@ Represents a directory in the content graph (future enhancement).
 2. Watches for `boot.Module` nodes from the kernel
 3. For each module, creates:
    - An `Asset` node (backward compatibility with existing consumers)
-   - A `content.File` node with computed content hash and MIME type
+   - A `fs.File` node with computed content hash and MIME type
 4. Bytespaces point directly to physical memory (HHDM-mapped, zero-copy)
 
 ### ISO9660 Source
@@ -86,7 +86,7 @@ Represents a directory in the content graph (future enhancement).
 3. Creates a `content.Source` node with kind `"iso9660_disk"` and priority 50
 4. For each file:
    - Creates a `boot.Module` node (backward compatibility)
-   - Creates a `content.File` node with computed content hash and MIME type
+   - Creates a `fs.File` node with computed content hash and MIME type
 5. Bytespaces are dynamically allocated and populated from disk reads
 
 ### Content Discovery
@@ -94,7 +94,7 @@ Represents a directory in the content graph (future enhancement).
 Consumers can discover content in two ways:
 
 1. **By source**: Query `content.Source` nodes, then traverse `content.contains` relationships
-2. **By type**: Query `content.File` nodes directly, filter by `file.source` if needed
+2. **By type**: Query `fs.File` nodes directly, filter by `file.source` if needed
 
 ### Overlay Resolution
 
@@ -189,7 +189,7 @@ The system maintains full backward compatibility:
 2. **Boot Modules**: `iso_reader` still creates `boot.Module` nodes
 3. **Existing Consumers**: Services like `fontd`, `blossom`, etc. continue to work unchanged
 
-The new `content.File` nodes augment (not replace) the existing system, providing a unified view while preserving all existing functionality.
+The new `fs.File` nodes augment (not replace) the existing system, providing a unified view while preserving all existing functionality.
 
 ## Future Enhancements
 

--- a/docs/IMPLEMENTATION_SUMMARY.md
+++ b/docs/IMPLEMENTATION_SUMMARY.md
@@ -10,8 +10,8 @@ Successfully implemented a unified content provider service that materializes fi
 
 **New Node Kinds:**
 - `content.Source`: Represents a content provider (Limine, ISO, etc.)
-- `content.File`: Unified file abstraction across all sources
-- `content.Directory`: Directory structure (schema defined, implementation deferred)
+- `fs.File`: Unified file abstraction across all sources
+- `fs.Directory`: Directory structure (schema defined, implementation deferred)
 
 **New Properties:**
 - ContentSource: `kind`, `name`, `priority`, `state`, `gen`


### PR DESCRIPTION
Updated `abi/tests/content_provider_schema.rs` to expect `fs.Directory` and `fs.File` instead of `content.Directory` and `content.File`, matching the `abi/src/schema.rs` implementation. Also updated `docs/CONTENT_PROVIDER.md` and `docs/IMPLEMENTATION_SUMMARY.md` to reflect the `fs.*` namespace change.

---
*PR created automatically by Jules for task [1740147757192233052](https://jules.google.com/task/1740147757192233052) started by @dancxjo*