### PR TITLE
Fix kernel test compilation and clean up warnings

### DIFF
--- a/kernel/src/task/scheduler/spawn.rs
+++ b/kernel/src/task/scheduler/spawn.rs
@@ -380,7 +380,6 @@ mod tests {
     use crate::task::TaskPriority;
     use crate::{BootRuntime, BootRuntimeBase, BootTasking, UserEntry, UserTaskSpec};
 
-    struct MockArch;
     #[derive(Clone, Copy, Default)]
     struct MockContext(usize);
     #[derive(Clone, Copy, Default)]
@@ -442,7 +441,7 @@ mod tests {
         ) -> Self::Context {
             MockContext(_spec.arg)
         }
-        unsafe fn switch(&self, _f: &mut Self::Context, _t: &Self::Context) {}
+        unsafe fn switch(&self, _f: &mut Self::Context, _t: &Self::Context, _tid: u64) {}
         unsafe fn enter_user(&self, _e: UserEntry) -> ! {
             loop {}
         }

--- a/kernel/src/tests/watch_overflow_test.rs
+++ b/kernel/src/tests/watch_overflow_test.rs
@@ -3,14 +3,8 @@
 //! Verifies that the watch system correctly handles overflow scenarios
 //! and maintains cursor monotonicity.
 
-use crate::root::graph::{
-    COMMIT_HISTORY_MAX_COMMITS, CommitHistory, CommitSummary, Graph, WatchFilter,
-};
-use crate::root::handlers::watch::{handle_watch_close, handle_watch_next, handle_watch_open};
-use crate::root::query::PreparedStep;
-use crate::root::symbols::Interner;
+use crate::root::graph::{CommitHistory, CommitSummary};
 use alloc::vec;
-use alloc::vec::Vec;
 
 /// Test that a watch receives EOVERFLOW when its cursor falls behind oldest history.
 #[cfg(test)]


### PR DESCRIPTION
This PR fixes a compilation error in the kernel tests caused by a mismatch between the `MockRuntime` implementation and the `BootTasking` trait definition. It also performs some housekeeping by removing unused imports and structs in the test modules, clearing up compiler warnings.

Verified by running `cargo test -p kernel` which now passes.

---
*PR created automatically by Jules for task [862996698272099340](https://jules.google.com/task/862996698272099340) started by @dancxjo*