### PR TITLE
⚖️ Steward: Event-driven window discovery in Blossom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "itoa",
@@ -317,7 +317,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.12",
  "http-body",
  "mime",
  "rustversion",
@@ -334,7 +334,7 @@ dependencies = [
  "arc-swap",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -1264,6 +1264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fortune"
 version = "0.1.0"
 dependencies = [
@@ -1271,15 +1280,6 @@ dependencies = [
  "llm",
  "ollama",
  "stem",
-]
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
 ]
 
 [[package]]
@@ -1482,7 +1482,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -1581,6 +1581,7 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
@@ -1597,7 +1598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -1630,7 +1631,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "httparse",
  "httpdate",
@@ -1650,7 +1651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.12",
  "hyper",
  "rustls",
  "tokio",
@@ -2349,7 +2350,7 @@ name = "ollama"
 version = "0.1.0"
 dependencies = [
  "abi",
- "http",
+ "http 0.1.0",
  "llm",
  "serde",
  "serde_json",
@@ -2856,7 +2857,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "hyper-rustls",

--- a/userspace/blossom/src/main.rs
+++ b/userspace/blossom/src/main.rs
@@ -196,6 +196,9 @@ struct UiWatcher {
     buf: [u8; 4096],
 }
 
+// "kind" as u32 little-endian: 'k' | 'i'<<8 | 'n'<<16 | 'd'<<24
+const PRED_KIND: u32 = 0x646E696B;
+
 struct UiPipeline {
     watchers: Vec<UiWatcher>,
     windows: BTreeMap<ThingId, WindowState>,
@@ -233,15 +236,38 @@ impl UiPipeline {
             }
         }
 
-        Self {
+        // Register watch for new window creation events
+        if let Ok(window_kind_id) = stem::thing::sys::intern(kinds::UI_WINDOW) {
+            let filter = RootWatchFilter::kind(window_kind_id);
+            let spec = WatchSpec {
+                mode: WatchMode::StreamOnly as u32,
+                filter_ptr: &filter as *const _ as u64,
+                filter_len: core::mem::size_of::<RootWatchFilter>() as u64,
+                ..Default::default()
+            };
+            if let Ok(id) = syscall::root_watch_open(&spec) {
+                watchers.push(UiWatcher {
+                    id,
+                    key: PRED_KIND,
+                    seq: 0,
+                    buf: [0u8; 4096],
+                });
+            }
+        }
+
+        let mut pipeline = Self {
             watchers,
             windows: BTreeMap::new(),
             ui_symbols: graph_ui::UiSymbols::intern_sys(),
-        }
+        };
+
+        // Initial census of existing windows
+        pipeline.refresh_windows();
+
+        pipeline
     }
 
     fn poll(&mut self) {
-        self.refresh_windows();
         let mut dirty: BTreeMap<ThingId, bool> = BTreeMap::new();
 
         for watcher in &mut self.watchers {
@@ -255,7 +281,32 @@ impl UiPipeline {
                         cursor = cursor.saturating_add(event_len);
                         let pred = header.predicate.to_u32_lossy();
                         if pred == watcher.key {
-                            dirty.insert(header.subject, true);
+                            if pred == PRED_KIND {
+                                // Check op type (Upsert=1, Delete=2)
+                                if let Some(op) = watch::WatchOp::from_u8(header.op) {
+                                    match op {
+                                        watch::WatchOp::Upsert => {
+                                            // New window created: start tracking it
+                                            self.windows.entry(header.subject).or_insert(WindowState {
+                                                last_gen: 0,
+                                                last_w: 0,
+                                                last_h: 0,
+                                                last_bg: 0,
+                                                last_title_bs: 0,
+                                                last_focused: false,
+                                            });
+                                            dirty.insert(header.subject, true);
+                                        }
+                                        watch::WatchOp::Delete => {
+                                            // Window deleted: stop tracking
+                                            self.windows.remove(&header.subject);
+                                            dirty.remove(&header.subject);
+                                        }
+                                    }
+                                }
+                            } else {
+                                dirty.insert(header.subject, true);
+                            }
                         }
                     } else {
                         break;


### PR DESCRIPTION
This change improves system efficiency by removing a frequent graph scan in the UI compositor service (`blossom`). It aligns with the Steward's directive to "Replace graph scans with Root registry links" (or in this case, watches) and improves inspectability by making window lifecycle events explicit.

It also includes a fix for a corrupt `Cargo.lock` file encountered during verification.

---
*PR created automatically by Jules for task [412760883618659721](https://jules.google.com/task/412760883618659721) started by @dancxjo*