### PR TITLE
Add Flexbox centering unit test to Blossom

### DIFF
--- a/userspace/blossom/src/emit_paint.rs
+++ b/userspace/blossom/src/emit_paint.rs
@@ -601,6 +601,7 @@ mod tests {
     use crate::scene::SceneGraph;
     use abi::ui_paint::{PaintOpTag, PaintReader};
     use abi::ui_scene::{EdgeInsets, NodeKind, SizeKind, SizeSpec, StringRef, TextMeta};
+    use alloc::vec;
 
     #[test]
     fn emit_text_op() {
@@ -648,13 +649,28 @@ mod tests {
             flex_meta: None,
             text_meta: Some(TextMeta {
                 text: StringRef { offset: 0, len: 5 },
-                font: StringRef { offset: 0, len: 0 },
+                font_kind: abi::ui_scene::FontKeyKind::Name,
+                font_name: StringRef { offset: 0, len: 0 },
+                font_thing: 0,
                 size: 12,
+                weight: 4,
+                style: 0,
+                wrap: abi::ui_scene::TextWrap::NoWrap,
+                ellipsis: false,
                 color: 0xFFFFFFFF,
             }),
             rect_meta: None,
             image_meta: None,
             checkbox_meta: None,
+            text_input_meta: None,
+            button_meta: None,
+            label_meta: None,
+            message_box_meta: None,
+            line_meta: None,
+            icon_meta: None,
+            scroll_meta: None,
+            spacer_meta: None,
+            separator_meta: None,
         });
 
         let layout = vec![LayoutRect {

--- a/userspace/blossom/src/graph_ui.rs
+++ b/userspace/blossom/src/graph_ui.rs
@@ -727,7 +727,8 @@ mod tests {
             UiEventKind::from_raw(decoded.kind),
             Some(UiEventKind::Toggled)
         );
-        assert_eq!(decoded.node_id, checkbox_id.to_u64_lossy());
+        let node_id = decoded.node_id;
+        assert_eq!(node_id, checkbox_id.to_u64_lossy());
         assert_eq!(decoded.checked, new_checked as u8);
     }
 }

--- a/userspace/blossom/src/layout/mod.rs
+++ b/userspace/blossom/src/layout/mod.rs
@@ -545,6 +545,15 @@ mod tests {
             rect_meta: None,
             image_meta: None,
             checkbox_meta: None,
+            text_input_meta: None,
+            button_meta: None,
+            label_meta: None,
+            message_box_meta: None,
+            line_meta: None,
+            icon_meta: None,
+            scroll_meta: None,
+            spacer_meta: None,
+            separator_meta: None,
         });
         scene.nodes.push(SceneNode {
             id: 1,
@@ -587,6 +596,15 @@ mod tests {
             rect_meta: None,
             image_meta: None,
             checkbox_meta: None,
+            text_input_meta: None,
+            button_meta: None,
+            label_meta: None,
+            message_box_meta: None,
+            line_meta: None,
+            icon_meta: None,
+            scroll_meta: None,
+            spacer_meta: None,
+            separator_meta: None,
         });
 
         let rects = layout_scene(
@@ -600,5 +618,72 @@ mod tests {
         );
         assert_eq!(rects[0].w, 200);
         assert!(rects[1].y >= 0);
+    }
+
+    fn default_node(id: u32, kind: NodeKind) -> SceneNode {
+        SceneNode {
+            id,
+            parent: None,
+            children: Vec::new(),
+            kind,
+            width: SizeSpec { kind: SizeKind::Auto, value: 0 },
+            height: SizeSpec { kind: SizeKind::Auto, value: 0 },
+            flex_basis: SizeSpec { kind: SizeKind::Auto, value: 0 },
+            min_width: None, min_height: None, max_width: None, max_height: None,
+            margin: EdgeInsets { left: 0, top: 0, right: 0, bottom: 0 },
+            padding: EdgeInsets { left: 0, top: 0, right: 0, bottom: 0 },
+            flex_grow: 0.0,
+            flex_shrink: 0.0,
+            window_meta: None, flex_meta: None, text_meta: None, rect_meta: None,
+            image_meta: None, line_meta: None, icon_meta: None, scroll_meta: None,
+            spacer_meta: None, separator_meta: None, checkbox_meta: None,
+            text_input_meta: None, button_meta: None, label_meta: None, message_box_meta: None,
+        }
+    }
+
+    #[test]
+    fn flex_row_center_center_exact() {
+        let mut scene = SceneGraph {
+            nodes: Vec::new(),
+            strings: Vec::new(),
+            root: 0,
+        };
+
+        // Root: Flex Row, 200x200, Center/Center
+        let mut root = default_node(0, NodeKind::Flex);
+        root.children = vec![1];
+        root.width = SizeSpec { kind: SizeKind::Px, value: 200 };
+        root.height = SizeSpec { kind: SizeKind::Px, value: 200 };
+        root.flex_meta = Some(FlexMeta {
+            direction: FlexDirection::Row,
+            align: AlignItems::Center,
+            justify: JustifyContent::Center,
+            gap: 0,
+        });
+        scene.nodes.push(root);
+
+        // Child: Fixed 50x50
+        let mut child = default_node(1, NodeKind::Rect);
+        child.parent = Some(0);
+        child.width = SizeSpec { kind: SizeKind::Px, value: 50 };
+        child.height = SizeSpec { kind: SizeKind::Px, value: 50 };
+        scene.nodes.push(child);
+
+        let rects = layout_scene(
+            &scene,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                w: 200,
+                h: 200,
+            },
+        );
+
+        // Expected: (200-50)/2 = 75
+        let child_rect = rects[1];
+        assert_eq!(child_rect.x, 75, "Child X should be centered (75)");
+        assert_eq!(child_rect.y, 75, "Child Y should be centered (75)");
+        assert_eq!(child_rect.w, 50, "Child width should be 50");
+        assert_eq!(child_rect.h, 50, "Child height should be 50");
     }
 }


### PR DESCRIPTION
This PR adds a thoughtful unit test for Flexbox layout centering in the `blossom` UI service. It verifies that a child element is correctly centered within a parent container when both `JustifyContent` and `AlignItems` are set to `Center`.

Additionally, this PR fixes several build errors in the `blossom` test suite that were preventing tests from running:
1.  Updated `emit_paint.rs` tests to use the correct fields for `SceneNode` and `TextMeta` (e.g., `font_name`, `weight` as u8).
2.  Fixed an `E0793` error in `graph_ui.rs` where a field of a packed struct was being passed by reference to `assert_eq!`.
3.  Added a `default_node` helper function to reduce boilerplate in layout tests.

---
*PR created automatically by Jules for task [10687875717784123421](https://jules.google.com/task/10687875717784123421) started by @dancxjo*