### PR TITLE
⚖️ Steward: Eliminate allocations in graph query hot path

### DIFF
--- a/kernel/src/root/handlers/graph.rs
+++ b/kernel/src/root/handlers/graph.rs
@@ -224,6 +224,7 @@ pub fn handle_query(
     plan: &[crate::root::query::PreparedStep],
     out_buffer: u64,
     out_len: u64,
+    scratch: &mut crate::root::query::QueryScratch,
 ) -> HandlerResult {
     let max_rows = (out_len as usize) / core::mem::size_of::<abi::query::QueryRow>();
     // Use stack buffer for small queries (<= 32 rows, 1KB) to avoid allocation.
@@ -232,10 +233,10 @@ pub fn handle_query(
 
     if max_rows <= STACK_CAP {
         let mut stack_buf = [abi::query::QueryRow::default(); STACK_CAP];
-        execute_and_copy(graph, plan, &mut stack_buf[..max_rows], out_buffer)
+        execute_and_copy(graph, plan, &mut stack_buf[..max_rows], out_buffer, scratch)
     } else {
         let mut krows = alloc::vec![abi::query::QueryRow::default(); max_rows];
-        execute_and_copy(graph, plan, &mut krows, out_buffer)
+        execute_and_copy(graph, plan, &mut krows, out_buffer, scratch)
     }
 }
 
@@ -244,8 +245,9 @@ fn execute_and_copy(
     plan: &[crate::root::query::PreparedStep],
     buffer: &mut [abi::query::QueryRow],
     out_buffer: u64,
+    scratch: &mut crate::root::query::QueryScratch,
 ) -> HandlerResult {
-    let res = crate::root::query::execute(graph, plan, buffer);
+    let res = crate::root::query::execute(graph, plan, buffer, scratch);
 
     if let Ok(count) = res {
         unsafe {
@@ -430,10 +432,12 @@ mod tests {
     #[test]
     fn test_handle_query_optimization() {
         use crate::root::query::PreparedStep;
+        use crate::root::query::QueryScratch;
         use abi::query::QueryRow;
 
         let mut graph = Graph::new();
         let mut interner = Interner::new();
+        let mut scratch = QueryScratch::new();
 
         let kind = interner.intern("TestKind");
         let id1 = graph.alloc(kind);
@@ -455,7 +459,7 @@ mod tests {
         let buf_ptr = buffer_stack.as_mut_ptr() as u64;
         let buf_len = buffer_stack.len() as u64;
 
-        let (status, count) = handle_query(&graph, &plan, buf_ptr, buf_len);
+        let (status, count) = handle_query(&graph, &plan, buf_ptr, buf_len, &mut scratch);
         assert_eq!(status, 0);
         assert_eq!(count, 3);
 
@@ -476,7 +480,7 @@ mod tests {
         let buf_ptr_heap = buffer_heap.as_mut_ptr() as u64;
         let buf_len_heap = buffer_heap.len() as u64;
 
-        let (status, count) = handle_query(&graph, &plan, buf_ptr_heap, buf_len_heap);
+        let (status, count) = handle_query(&graph, &plan, buf_ptr_heap, buf_len_heap, &mut scratch);
         assert_eq!(status, 0);
         assert_eq!(count, 3);
 

--- a/kernel/src/root/query.rs
+++ b/kernel/src/root/query.rs
@@ -11,7 +11,37 @@ pub struct PreparedStep {
     pub symbol: SymbolId,
 }
 
-pub fn execute(graph: &Graph, plan: &[PreparedStep], out: &mut [QueryRow]) -> Result<usize, ()> {
+pub struct QueryScratch {
+    pub rows_a: Vec<QueryRow>,
+    pub rows_b: Vec<QueryRow>,
+}
+
+impl QueryScratch {
+    pub fn new() -> Self {
+        Self {
+            rows_a: Vec::with_capacity(128),
+            rows_b: Vec::with_capacity(128),
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.rows_a.clear();
+        self.rows_b.clear();
+    }
+}
+
+impl Default for QueryScratch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn execute(
+    graph: &Graph,
+    plan: &[PreparedStep],
+    out: &mut [QueryRow],
+    scratch: &mut QueryScratch,
+) -> Result<usize, ()> {
     if plan.is_empty() {
         return Ok(0);
     }
@@ -19,12 +49,18 @@ pub fn execute(graph: &Graph, plan: &[PreparedStep], out: &mut [QueryRow]) -> Re
     // Steward Improvement: Double-buffering strategy.
     // We maintain two vectors and swap them after each step to reuse capacity.
     // This avoids repeated heap allocations in the query hot path.
-    let mut current_rows: Vec<QueryRow> = Vec::new();
-    let mut next_rows: Vec<QueryRow> = Vec::new();
+    scratch.reset();
+
+    // Move buffers out of scratch to avoid simultaneous mutable borrow issues.
+    // `mem::take` replaces the scratch fields with default empty Vecs.
+    // The original Vecs (with their capacity) are moved to local variables.
+    // We will move them back to `scratch` before returning to preserve capacity.
+    let mut current_rows = core::mem::take(&mut scratch.rows_a);
+    let mut next_rows = core::mem::take(&mut scratch.rows_b);
 
     // Step 0: Source (Scan or Start)
     let step0 = &plan[0];
-    
+
     if step0.op == 1 {
         // Scan: initialize with all nodes of a given kind
         let kind_sym = step0.symbol;
@@ -83,6 +119,9 @@ pub fn execute(graph: &Graph, plan: &[PreparedStep], out: &mut [QueryRow]) -> Re
             }
         }
     } else {
+        // Restore scratch before returning
+        scratch.rows_a = current_rows;
+        scratch.rows_b = next_rows;
         return Err(()); // Must be Scan or Start or Anchor
     }
 
@@ -150,7 +189,12 @@ pub fn execute(graph: &Graph, plan: &[PreparedStep], out: &mut [QueryRow]) -> Re
                     }
                 }
             }
-            _ => return Err(()),
+            _ => {
+                // Restore scratch before returning
+                scratch.rows_a = current_rows;
+                scratch.rows_b = next_rows;
+                return Err(());
+            }
         }
         core::mem::swap(&mut current_rows, &mut next_rows);
     }
@@ -159,6 +203,10 @@ pub fn execute(graph: &Graph, plan: &[PreparedStep], out: &mut [QueryRow]) -> Re
     for i in 0..count {
         out[i] = current_rows[i];
     }
+
+    // Restore scratch buffers (retaining capacity)
+    scratch.rows_a = current_rows;
+    scratch.rows_b = next_rows;
 
     Ok(count)
 }
@@ -171,6 +219,7 @@ mod tests {
     #[test]
     fn test_query_execution_scenarios() {
         let mut graph = Graph::new();
+        let mut scratch = QueryScratch::new();
 
         // Define symbols
         let kind_person = 100;
@@ -215,7 +264,7 @@ mod tests {
         ];
 
         let mut out = [QueryRow::default(); 10];
-        let count = execute(&graph, &plan1, &mut out).expect("Plan 1 failed");
+        let count = execute(&graph, &plan1, &mut out, &mut scratch).expect("Plan 1 failed");
 
         assert_eq!(count, 1);
         assert_eq!(out[0].id, p2);
@@ -228,7 +277,7 @@ mod tests {
             PreparedStep { op: 3, symbol: rel_authored, arg1: 1, arg2: 0 }, // In
         ];
 
-        let count = execute(&graph, &plan2, &mut out).expect("Plan 2 failed");
+        let count = execute(&graph, &plan2, &mut out, &mut scratch).expect("Plan 2 failed");
 
         // Post1 is authored by P2. Post2 is authored by nobody.
         // Scan returns Post1, Post2.
@@ -248,7 +297,7 @@ mod tests {
             PreparedStep { op: 3, symbol: rel_liked, arg1: 0, arg2: 0 },
         ];
 
-        let count = execute(&graph, &plan3, &mut out).expect("Plan 3 failed");
+        let count = execute(&graph, &plan3, &mut out, &mut scratch).expect("Plan 3 failed");
         assert_eq!(count, 2);
 
         // Order depends on Scan order (kind_index order) and Expand order.
@@ -280,13 +329,14 @@ mod tests {
                 arg2: 0,
             },
         ];
-        let count = execute(&graph, &plan4, &mut out).expect("Plan 4 failed");
+        let count = execute(&graph, &plan4, &mut out, &mut scratch).expect("Plan 4 failed");
         assert_eq!(count, 3);
     }
 
     #[test]
     fn test_query_reverse_index_optimization() {
         let mut graph = Graph::new();
+        let mut scratch = QueryScratch::new();
         let kind_a = 1;
         let kind_b = 2;
         let rel_x = 10;
@@ -318,7 +368,7 @@ mod tests {
         ];
 
         let mut out = [QueryRow::default(); 10];
-        let count = execute(&graph, &plan, &mut out).expect("Plan failed");
+        let count = execute(&graph, &plan, &mut out, &mut scratch).expect("Plan failed");
 
         assert_eq!(count, 2);
 
@@ -335,6 +385,7 @@ mod tests {
     #[test]
     fn test_query_start_op_and_edge_cases() {
         let mut graph = Graph::new();
+        let mut scratch = QueryScratch::new();
         let kind_a = 1;
         let kind_empty = 2;
         let prop_x = 10;
@@ -356,7 +407,7 @@ mod tests {
             arg1: n1,
             arg2: 0,
         }];
-        let count = execute(&graph, &plan_start_valid, &mut out).expect("Start valid failed");
+        let count = execute(&graph, &plan_start_valid, &mut out, &mut scratch).expect("Start valid failed");
         assert_eq!(count, 1);
         assert_eq!(out[0].id, n1);
         assert_eq!(out[0].kind_rel, kind_a as u64);
@@ -368,7 +419,7 @@ mod tests {
             arg1: 999999,
             arg2: 0,
         }];
-        let count = execute(&graph, &plan_start_invalid, &mut out).expect("Start invalid failed");
+        let count = execute(&graph, &plan_start_invalid, &mut out, &mut scratch).expect("Start invalid failed");
         assert_eq!(count, 0);
 
         // 3. Test Scan(Op 1) with empty kind
@@ -378,7 +429,7 @@ mod tests {
             arg1: 0,
             arg2: 0,
         }];
-        let count = execute(&graph, &plan_scan_empty, &mut out).expect("Scan empty failed");
+        let count = execute(&graph, &plan_scan_empty, &mut out, &mut scratch).expect("Scan empty failed");
         assert_eq!(count, 0);
 
         // 4. Test Scan + FilterEq where property is missing on some nodes
@@ -398,7 +449,7 @@ mod tests {
                 arg2: 0,
             },
         ];
-        let count = execute(&graph, &plan_filter_hit, &mut out).expect("Filter hit failed");
+        let count = execute(&graph, &plan_filter_hit, &mut out, &mut scratch).expect("Filter hit failed");
         assert_eq!(count, 1);
         assert_eq!(out[0].id, n1);
 
@@ -417,7 +468,7 @@ mod tests {
                 arg2: 0,
             },
         ];
-        let count = execute(&graph, &plan_filter_miss_val, &mut out).expect("Filter miss val failed");
+        let count = execute(&graph, &plan_filter_miss_val, &mut out, &mut scratch).expect("Filter miss val failed");
         assert_eq!(count, 0);
     }
 
@@ -426,6 +477,7 @@ mod tests {
         use crate::root::graph_anchors;
 
         let mut graph = Graph::new();
+        let mut scratch = QueryScratch::new();
         // Create nodes
         let host_kind = 10;
         let root_kind = 11;
@@ -449,7 +501,7 @@ mod tests {
             symbol: 0,
         }];
 
-        let count = execute(&graph, &plan_host, &mut out).expect("Anchor Host failed");
+        let count = execute(&graph, &plan_host, &mut out, &mut scratch).expect("Anchor Host failed");
         assert_eq!(count, 1);
         assert_eq!(out[0].id, host_id);
         assert_eq!(out[0].kind_rel, host_kind as u64);
@@ -462,7 +514,7 @@ mod tests {
             symbol: 0,
         }];
 
-        let count = execute(&graph, &plan_root, &mut out).expect("Anchor Root failed");
+        let count = execute(&graph, &plan_root, &mut out, &mut scratch).expect("Anchor Root failed");
         assert_eq!(count, 1);
         assert_eq!(out[0].id, root_id);
         assert_eq!(out[0].kind_rel, root_kind as u64);
@@ -476,13 +528,14 @@ mod tests {
         }];
 
         // It should return 0 rows if anchor is missing or not in graph
-        let count = execute(&graph, &plan_kernel, &mut out).expect("Anchor Kernel failed");
+        let count = execute(&graph, &plan_kernel, &mut out, &mut scratch).expect("Anchor Kernel failed");
         assert_eq!(count, 0);
     }
 
     #[test]
     fn test_query_chaining_and_limits() {
         let mut graph = Graph::new();
+        let mut scratch = QueryScratch::new();
         let kind_node = 1;
         let rel_link = 10;
 
@@ -503,7 +556,7 @@ mod tests {
             PreparedStep { op: 3, symbol: rel_link, arg1: 1, arg2: 0 }, // Expand In (finds P)
             PreparedStep { op: 3, symbol: rel_link, arg1: 1, arg2: 0 }, // Expand In (finds GP)
         ];
-        let count = execute(&graph, &plan_in, &mut out).expect("Plan In failed");
+        let count = execute(&graph, &plan_in, &mut out, &mut scratch).expect("Plan In failed");
         assert_eq!(count, 1);
         // Result is edge P -> GP (where id=GP, val_dst=P)
         assert_eq!(out[0].id, gp);
@@ -519,7 +572,7 @@ mod tests {
             PreparedStep { op: 3, symbol: rel_link, arg1: 0, arg2: 0 }, // Expand Out (finds P)
             PreparedStep { op: 3, symbol: rel_link, arg1: 0, arg2: 0 }, // Expand Out (finds P again from GP)
         ];
-        let count = execute(&graph, &plan_out, &mut out).expect("Plan Out failed");
+        let count = execute(&graph, &plan_out, &mut out, &mut scratch).expect("Plan Out failed");
         assert_eq!(count, 1);
         assert_eq!(out[0].id, gp);
         assert_eq!(out[0].val_dst, p);
@@ -533,7 +586,7 @@ mod tests {
             PreparedStep { op: 3, symbol: rel_link, arg1: 0, arg2: 0 }, // Expand Out
         ];
         let mut small_out = [QueryRow::default(); 1];
-        let count = execute(&graph, &plan_scan, &mut small_out).expect("Plan Limit failed");
+        let count = execute(&graph, &plan_scan, &mut small_out, &mut scratch).expect("Plan Limit failed");
         assert_eq!(count, 1); // Should be truncated to 1
     }
 }

--- a/kernel/src/root/service.rs
+++ b/kernel/src/root/service.rs
@@ -23,6 +23,8 @@ pub extern "C" fn root_main<R: BootRuntime>(_arg: usize) -> ! {
     crate::contract!("ROOT: LogSymbols initialized");
     let mut batch_scratch = RootBatchScratch::new();
     crate::contract!("ROOT: BatchScratch initialized");
+    let mut query_scratch = crate::root::query::QueryScratch::new();
+    crate::contract!("ROOT: QueryScratch initialized");
 
     let mut iteration = 0u64;
     crate::contract!("ROOT: Entering main loop");
@@ -51,6 +53,7 @@ pub extern "C" fn root_main<R: BootRuntime>(_arg: usize) -> ! {
                     &mut interner,
                     &mut log_symbols,
                     &mut batch_scratch,
+                    &mut query_scratch,
                     msg,
                 );
                 processed += 1;
@@ -109,6 +112,7 @@ fn handle_msg<R: BootRuntime>(
     interner: &mut Interner,
     log_symbols: &mut root_handlers::logging::LogSymbols,
     batch_scratch: &mut RootBatchScratch,
+    query_scratch: &mut crate::root::query::QueryScratch,
     msg: RootMsg,
 ) {
     let (status, value) = match msg.op {
@@ -130,7 +134,7 @@ fn handle_msg<R: BootRuntime>(
             plan,
             out_buffer,
             out_len,
-        } => root_handlers::handle_query(graph, &plan, out_buffer, out_len),
+        } => root_handlers::handle_query(graph, &plan, out_buffer, out_len, query_scratch),
 
         // Property operations
         RootOp::PropGet { id, key } => root_handlers::handle_prop_get(graph, interner, id, key),


### PR DESCRIPTION
What: Introduced `QueryScratch` double-buffering strategy in `kernel/src/root/query.rs` and updated `handle_query` to use it.
Why: To eliminate repeated heap allocations (`Vec::new`) in the `execute` function, which is a hot path for all graph queries. This aligns with the constitutional principle of reducing overhead and ensuring predictable performance.
Impact: Query execution now reuses existing buffers, reducing allocator pressure and improving performance for high-frequency queries.
Verification: Ran `cargo test -p kernel` to ensure all tests pass.
Constitutional Check:
*   Graph remains authoritative.
*   Syscall surface unchanged.
*   Provenance/security unchanged.
*   Determinism preserved.
*   System still boots (kernel tests pass).

---
*PR created automatically by Jules for task [1630630644164392668](https://jules.google.com/task/1630630644164392668) started by @dancxjo*