### PR TITLE
Add unit test for find_subsequence in libs/http

### DIFF
--- a/libs/http/src/lib.rs
+++ b/libs/http/src/lib.rs
@@ -340,4 +340,32 @@ mod tests {
         // Non-numeric
         assert_eq!(parse_ipv4("a.b.c.d"), Err(()));
     }
+
+    #[test]
+    fn test_find_subsequence() {
+        let sep = b"\r\n\r\n";
+
+        // Found at end (typical header case)
+        let data = b"Hello world\r\n\r\n";
+        assert_eq!(find_subsequence(data, sep), Some(11));
+
+        // Found in middle
+        let data2 = b"Hello\r\n\r\nBody";
+        assert_eq!(find_subsequence(data2, sep), Some(5));
+
+        // Not found
+        let data3 = b"Hello world";
+        assert_eq!(find_subsequence(data3, sep), None);
+
+        // Found at start
+        let data4 = b"\r\n\r\nStart";
+        assert_eq!(find_subsequence(data4, sep), Some(0));
+
+        // Partial match
+        let data5 = b"Partial\r\n\rEnd";
+        assert_eq!(find_subsequence(data5, sep), None);
+
+        // Overlapping needle
+        assert_eq!(find_subsequence(b"aaaaa", b"aa"), Some(0));
+    }
 }


### PR DESCRIPTION
Added a unit test for `find_subsequence` in `libs/http/src/lib.rs`.
Verified with `cargo test -p http`.
Note: Running tests required creating a dummy `assets/pci/pci.ids` file to satisfy `stem` build dependencies. This file was removed after testing.

---
*PR created automatically by Jules for task [6942737595474109506](https://jules.google.com/task/6942737595474109506) started by @dancxjo*