### PR TITLE
Fix stale content provider schema test expectations

### DIFF
--- a/abi/tests/content_provider_schema.rs
+++ b/abi/tests/content_provider_schema.rs
@@ -19,8 +19,8 @@ fn test_content_source_states() {
 fn test_content_kinds_exist() {
     // Ensure content provider kinds are defined
     assert_eq!(kinds::CONTENT_SOURCE, "content.Source");
-    assert_eq!(kinds::CONTENT_DIR, "content.Directory");
-    assert_eq!(kinds::CONTENT_FILE, "content.File");
+    assert_eq!(kinds::CONTENT_DIR, "fs.Directory");
+    assert_eq!(kinds::CONTENT_FILE, "fs.File");
 }
 
 #[test]


### PR DESCRIPTION
Fixes a failing test in `abi/tests/content_provider_schema.rs` by updating the expected values for content provider kinds. The test was expecting legacy values (`content.Directory`, `content.File`) while the codebase had been updated to use `fs.Directory` and `fs.File`. This change ensures the test matches the actual implementation.


---
*PR created automatically by Jules for task [7118418120231095013](https://jules.google.com/task/7118418120231095013) started by @dancxjo*