### PR TITLE
Add System Stewardship Feature and Fix Build Tooling

### DIFF
--- a/bran/src/arch/aarch64/mod.rs
+++ b/bran/src/arch/aarch64/mod.rs
@@ -144,7 +144,7 @@ impl ArchRuntime for AArch64Runtime {
         task::init_user_context(spec, kstack_top)
     }
 
-    unsafe fn switch(&self, from: &mut Self::Context, to: &Self::Context) {
+    unsafe fn switch(&self, from: &mut Self::Context, to: &Self::Context, _to_tid: u64) {
         unsafe { task::switch(from, to) }
     }
 

--- a/bran/src/arch/loongarch64/mod.rs
+++ b/bran/src/arch/loongarch64/mod.rs
@@ -129,7 +129,7 @@ impl ArchRuntime for LoongArch64Runtime {
         task::init_user_context(spec, kstack_top)
     }
 
-    unsafe fn switch(&self, from: &mut Self::Context, to: &Self::Context) {
+    unsafe fn switch(&self, from: &mut Self::Context, to: &Self::Context, _to_tid: u64) {
         unsafe { task::switch(from, to) }
     }
 

--- a/bran/src/arch/riscv64/mod.rs
+++ b/bran/src/arch/riscv64/mod.rs
@@ -119,7 +119,7 @@ impl ArchRuntime for RISCV64Runtime {
         task::init_user_context(spec, kstack_top)
     }
 
-    unsafe fn switch(&self, from: &mut Self::Context, to: &Self::Context) {
+    unsafe fn switch(&self, from: &mut Self::Context, to: &Self::Context, _to_tid: u64) {
         unsafe { task::switch(from, to) }
     }
 

--- a/docs/behavior/features/system_stewardship.feature
+++ b/docs/behavior/features/system_stewardship.feature
@@ -1,0 +1,19 @@
+@steward
+Feature: System Stewardship
+
+  As a System Steward
+  I want to verify the integrity and responsiveness of the ThingOS system
+  So that I can ensure compliance with the ThingOS Constitution (clarity, correctness, responsiveness)
+
+  Scenario: Verify System Integrity and Visual Responsiveness
+    Given the machine is booting
+    When I wait for the system to reach ready state
+    Then the serial output should contain "SPROUT:"
+    And the serial output should contain "Supervisor starting"
+    And the serial output should contain "bloom: First frame rendered"
+    And I should see the desktop wallpaper
+    And I should see the "Clock" application
+    And the "Clock" application should be ticking
+    And I should see the "Font Explorer" application
+    And the log should not contain "PANIC"
+    And the log should not contain "ERROR"

--- a/xtask/src/image.rs
+++ b/xtask/src/image.rs
@@ -495,9 +495,15 @@ fn build_userspace_app_with_features(
 ) -> Result<()> {
     println!("Building {} ...", name);
 
+    let extra_flags = if target.ends_with(".json") {
+        vec!["-Z", "json-target-spec"]
+    } else {
+        vec![]
+    };
+
     let mut cmd = cmd!(
         sh,
-        "cargo -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem build --target {target} --profile {profile} -p {name}"
+        "cargo -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem {extra_flags...} build --target {target} --profile {profile} -p {name}"
     )
     .env("RUSTFLAGS", "-Awarnings");
 


### PR DESCRIPTION
This change introduces a new BDD feature file `system_stewardship.feature` that describes a comprehensive system verification scenario for a "System Steward" persona. It also fixes build issues in `xtask` (missing `-Z json-target-spec`) and `bran` (kernel architecture trait mismatch) that prevented the test suite from running successfully on various architectures. The tests can now be executed via `just behave`.

---
*PR created automatically by Jules for task [6234318344967345318](https://jules.google.com/task/6234318344967345318) started by @dancxjo*