### PR TITLE
Fix compilation of blossom graph_ui tests

### DIFF
--- a/userspace/blossom/src/graph_ui.rs
+++ b/userspace/blossom/src/graph_ui.rs
@@ -880,6 +880,8 @@ mod tests {
         let symbols = UiSymbols {
             rel_has_child: 201,
             rel_root_ui: 203,
+            rel_child_of: 202,
+            kind_window: 100,
             kind_button: 101,
             kind_checkbox: 102,
             kind_text: 103,
@@ -947,6 +949,8 @@ mod tests {
         let symbols = UiSymbols {
             rel_has_child: 201,
             rel_root_ui: 203,
+            rel_child_of: 202,
+            kind_window: 100,
             kind_button: 101,
             kind_checkbox: 102,
             kind_text: 103,


### PR DESCRIPTION
Resolved a compilation error in `userspace/blossom/src/graph_ui.rs` tests where `UiSymbols` struct initialization was missing `rel_child_of` and `kind_window` fields. Assigned appropriate values consistent with the `TestGraph` mock. This ensures the tests are maintainable and correct.

---
*PR created automatically by Jules for task [4789056780734008766](https://jules.google.com/task/4789056780734008766) started by @dancxjo*