### PR TITLE
Add tests for pagination and ordering in phloem and fix executor bug

### DIFF
--- a/userspace/phloem/src/executor.rs
+++ b/userspace/phloem/src/executor.rs
@@ -318,10 +318,17 @@ impl<G: Graph> GraphExecutor<G> {
                         }
                     }
                     None => {
+                        // If we are sorting, we must find ALL matching nodes, not just the limit.
+                        // Then we sort and apply limit/skip.
+                        let effective_limit = if order_by.is_some() {
+                            usize::MAX
+                        } else {
+                            limit_total
+                        };
                         matched_ids = self.discover_nodes(
                             &node_pat.props,
                             None,
-                            limit_total,
+                            effective_limit,
                             where_clause.as_ref(),
                             node_pat.var.as_deref(),
                         );
@@ -569,6 +576,7 @@ impl<G: Graph> GraphExecutor<G> {
 
             // Exhaustive kinds to seed from
             let fallback_kinds = [
+                "Kind",
                 "fs.File",
                 "content.Source",
                 "Asset",

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -458,4 +458,61 @@ mod tests {
         // Should fail because 'n' is not bound
         assert!(!res.success);
     }
+
+    // ===== 8) Pagination and Ordering =====
+
+    #[test]
+    fn test_pagination() {
+        // MATCH (n) RETURN n ORDER BY id(n) ASC SKIP 1 LIMIT 2
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+        let cmd = parse("MATCH (n) RETURN n ORDER BY id(n) ASC SKIP 1 LIMIT 2").unwrap();
+        let res = ex.execute(cmd);
+        assert!(res.success);
+        // Expecting nodes 2, 3
+        assert_eq!(res.rows.len(), 2);
+        if let crate::ResultValue::Node(id) = res.rows[0][0] {
+            assert_eq!(id, 2);
+        } else {
+            panic!("Expected Node ID");
+        }
+        if let crate::ResultValue::Node(id) = res.rows[1][0] {
+            assert_eq!(id, 3);
+        } else {
+            panic!("Expected Node ID");
+        }
+    }
+
+    #[test]
+    fn test_skip_overflow() {
+        // MATCH (n) RETURN n SKIP 100
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+        let cmd = parse("MATCH (n) RETURN n SKIP 100").unwrap();
+        let res = ex.execute(cmd);
+        assert!(res.success);
+        assert!(res.rows.is_empty());
+    }
+
+    #[test]
+    fn test_order_desc() {
+        // MATCH (n) RETURN n ORDER BY id(n) DESC LIMIT 2
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+        let cmd = parse("MATCH (n) RETURN n ORDER BY id(n) DESC LIMIT 2").unwrap();
+        let res = ex.execute(cmd);
+        assert!(res.success);
+        // Expecting nodes 5, 4 (reverse ID order)
+        assert_eq!(res.rows.len(), 2);
+        if let crate::ResultValue::Node(id) = res.rows[0][0] {
+            assert_eq!(id, 5);
+        } else {
+            panic!("Expected Node ID");
+        }
+        if let crate::ResultValue::Node(id) = res.rows[1][0] {
+            assert_eq!(id, 4);
+        } else {
+            panic!("Expected Node ID");
+        }
+    }
 }


### PR DESCRIPTION
This PR adds useful and thoughtful unit tests to `userspace/phloem` covering pagination (`SKIP` and `LIMIT`) and ordering (`ORDER BY`).
It also fixes a bug in the graph executor where `LIMIT` was being applied during node discovery even when `ORDER BY` was requested, which caused the executor to only sort the first N discovered nodes rather than finding all matches, sorting them, and then taking the top N.
Additionally, "Kind" was added to the fallback kinds list to ensure that `MATCH (n)` queries can discover "Kind" nodes if they are not otherwise reachable.

---
*PR created automatically by Jules for task [7376482009019734376](https://jules.google.com/task/7376482009019734376) started by @dancxjo*