### PR TITLE
fix(phloem): Wire up MERGE command and fix tautological test

### DIFF
--- a/userspace/phloem/src/executor.rs
+++ b/userspace/phloem/src/executor.rs
@@ -115,13 +115,10 @@ impl<G: Graph> GraphExecutor<G> {
             Command::Quit => ExecutionResult::message("Bye."),
             Command::Schema => ExecutionResult::error("Schema not implemented."),
             Command::Merge {
-                pattern: _,
-                returns: _,
+                pattern,
+                returns,
                 skip: _,
-            } => {
-                // TODO: Implement MERGE properly (for now it just MATCHes/CREATEs)
-                ExecutionResult::error("MERGE not fully implemented")
-            }
+            } => self.execute_merge(pattern, returns),
             Command::Match {
                 pattern,
                 where_clause,

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -423,8 +423,8 @@ mod tests {
         let mut ex = GraphExecutor::with_graph(&g);
         let cmd = parse("MERGE (n:Kind {key: 1}) RETURN count(n)").unwrap();
         let res = ex.execute(cmd);
-        // MERGE is not fully implemented, but should not panic
-        assert!(!res.success || res.success); // Either works or reports error
+        // MERGE should succeed now
+        assert!(res.success);
     }
 
     // ===== Parser-level tests for unsupported features =====


### PR DESCRIPTION
This PR fixes a tautological test in `userspace/phloem` and wires up the `MERGE` command implementation.

The `test_merge_node` test was previously asserting `!res.success || res.success`, which masked the fact that `MERGE` was returning an error ("not implemented").

I have:
1.  Updated the test to assert `res.success`.
2.  Updated `GraphExecutor::execute` to call `self.execute_merge` when it encounters `Command::Merge`.
3.  Verified that all tests in `phloem` pass.


---
*PR created automatically by Jules for task [16066394671207949162](https://jules.google.com/task/16066394671207949162) started by @dancxjo*