### PR TITLE
Fix Phloem ORDER BY with LIMIT bug and add regression test

### DIFF
--- a/userspace/phloem/src/executor.rs
+++ b/userspace/phloem/src/executor.rs
@@ -234,7 +234,12 @@ impl<G: Graph> GraphExecutor<G> {
     ) -> ExecutionResult {
         match pattern {
             Pattern::Node(node_pat) => {
-                let limit_total = limit + skip;
+                // If we need to order results, we must fetch all matching nodes first
+                let limit_total = if order_by.is_some() {
+                    usize::MAX
+                } else {
+                    limit + skip
+                };
                 let mut matched_ids = Vec::new();
 
                 // OPTIMIZATION: If WHERE id(n) = $id or id(n) = 123, just look up that node

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -289,6 +289,21 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_order_by_id_desc_limit() {
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+        let cmd = parse("MATCH (n) RETURN n ORDER BY id(n) DESC LIMIT 1").unwrap();
+        let res = ex.execute(cmd);
+        assert!(res.success);
+        assert_eq!(res.rows.len(), 1);
+        if let crate::ResultValue::Node(id) = res.rows[0][0] {
+            assert_eq!(id, 5);
+        } else {
+            panic!("Expected Node ID");
+        }
+    }
+
     // ===== 1) Identity and direct lookup =====
 
     #[test]


### PR DESCRIPTION
This PR adds a useful unit test for `ORDER BY ... DESC LIMIT ...` in the Phloem graph query engine.
While implementing the test, I discovered that `ORDER BY` was broken for queries without a kind specifier (e.g., `MATCH (n) ...`), as the executor was eagerly applying the `LIMIT` during the discovery phase, effectively ignoring the sort order.
I fixed this bug by disabling the early limit optimization when an `ORDER BY` clause is present.
The new test `test_order_by_id_desc_limit` now passes.

---
*PR created automatically by Jules for task [8014871722200370338](https://jules.google.com/task/8014871722200370338) started by @dancxjo*