### PR TITLE
Add system exploration feature and GQL steps

### DIFF
--- a/docs/behavior/features/system_exploration.feature
+++ b/docs/behavior/features/system_exploration.feature
@@ -1,0 +1,19 @@
+Feature: System Exploration via Graph API
+
+  As a developer or system administrator
+  I want to inspect the system state using the Graph Query Language (GQL) API
+  So that I can verify the topology of hardware, processes, and services without relying on opaque binary structures
+
+  Scenario: Exploring the process tree and memory map
+    Given the anther server is ready
+    When I execute the GQL query "MATCH (n:proc.Task) RETURN n"
+    Then the response status should be 200
+    And the response body should contain "proc.Task"
+
+    When I execute the GQL query "MATCH (c:dev.Cpu) RETURN c"
+    Then the response status should be 200
+    And the response body should contain "dev.Cpu"
+
+    When I execute the GQL query "MATCH (s:svc.Instance) RETURN s"
+    Then the response status should be 200
+    And the response body should contain "svc.Instance"

--- a/tools/bdd/src/steps.rs
+++ b/tools/bdd/src/steps.rs
@@ -1992,6 +1992,31 @@ async fn make_get_request(world: &mut ThingOsWorld, path: String) -> Result<(), 
     Ok(())
 }
 
+#[when(regex = r#"^I execute the GQL query "(.+)"$"#)]
+async fn execute_gql_query(world: &mut ThingOsWorld, query: String) -> Result<(), StepError> {
+    let port = world
+        .http_port
+        .ok_or(StepError("HTTP port not configured".to_string()))?;
+    let url = format!("http://127.0.0.1:{}/api/v1/query", port);
+
+    let client = Client::new();
+    let resp = client
+        .get(&url)
+        .query(&[("q", query)])
+        .send()
+        .await
+        .map_err(|e| StepError(format!("Request failed: {}", e)))?;
+
+    let status = resp.status().as_u16();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| StepError(format!("Failed to read body: {}", e)))?;
+
+    world.last_http_response = Some((status, body));
+    Ok(())
+}
+
 #[then(regex = r#"^the response status should be (\d+)$"#)]
 async fn check_response_status(world: &mut ThingOsWorld, status: u16) -> Result<(), StepError> {
     let (last_status, _) = world


### PR DESCRIPTION
Added a new BDD scenario for exploring the system graph via GQL API. Implemented the necessary step definition in `tools/bdd` to execute GQL queries. Validated the implementation logic, although full test execution was blocked by pre-existing environment issues.

---
*PR created automatically by Jules for task [4974979181406104799](https://jules.google.com/task/4974979181406104799) started by @dancxjo*