### PR TITLE
Fix MERGE command in phloem and enable correctly passing test

### DIFF
--- a/userspace/phloem/src/executor.rs
+++ b/userspace/phloem/src/executor.rs
@@ -115,13 +115,10 @@ impl<G: Graph> GraphExecutor<G> {
             Command::Quit => ExecutionResult::message("Bye."),
             Command::Schema => ExecutionResult::error("Schema not implemented."),
             Command::Merge {
-                pattern: _,
-                returns: _,
-                skip: _,
-            } => {
-                // TODO: Implement MERGE properly (for now it just MATCHes/CREATEs)
-                ExecutionResult::error("MERGE not fully implemented")
-            }
+                pattern,
+                returns,
+                skip,
+            } => self.execute_merge(pattern, returns, skip),
             Command::Match {
                 pattern,
                 where_clause,
@@ -151,6 +148,7 @@ impl<G: Graph> GraphExecutor<G> {
         &mut self,
         pattern: Pattern,
         returns: Vec<ReturnExpression>,
+        skip: usize,
     ) -> ExecutionResult {
         match pattern {
             Pattern::Node(node_pat) => {
@@ -163,8 +161,12 @@ impl<G: Graph> GraphExecutor<G> {
                 }
 
                 if returns.is_empty() {
-                    return ExecutionResult::success(&format!("ok: merged node (id:{})", id));
+                    return ExecutionResult::success(&format!("ok: merged node {}", self.format_node(id)));
                 } else {
+                    if skip > 0 {
+                        let cols: Vec<String> = returns.iter().map(|r| r.to_string()).collect();
+                        return ExecutionResult::rows(cols, Vec::new());
+                    }
                     return self.format_results_structured(&returns);
                 }
             }
@@ -213,6 +215,10 @@ impl<G: Graph> GraphExecutor<G> {
                                 // Bind the relationship if possible?
                                 // Actually we don't have a good way to bind "edge IDs" yet as they are just predicates.
                                 // For now we'll just return results.
+                            }
+                            if skip > 0 {
+                                let cols: Vec<String> = returns.iter().map(|r| r.to_string()).collect();
+                                return ExecutionResult::rows(cols, Vec::new());
                             }
                             self.format_results_structured(&returns)
                         }

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -423,8 +423,17 @@ mod tests {
         let mut ex = GraphExecutor::with_graph(&g);
         let cmd = parse("MERGE (n:Kind {key: 1}) RETURN count(n)").unwrap();
         let res = ex.execute(cmd);
-        // MERGE is not fully implemented, but should not panic
-        assert!(!res.success || res.success); // Either works or reports error
+        assert!(res.success, "MERGE command failed: {:?}", res.message);
+
+        // Check that we got a result
+        assert!(!res.rows.is_empty());
+        if let Some(row) = res.rows.first() {
+            if let Some(crate::ResultValue::Number(n)) = row.first() {
+                assert_eq!(*n, 1);
+            } else {
+                panic!("Expected number result");
+            }
+        }
     }
 
     // ===== Parser-level tests for unsupported features =====


### PR DESCRIPTION
I identified a wrongly passing test `test_merge_node` in `userspace/phloem/src/query_tests.rs` that was asserting `!res.success || res.success`. I fixed the test to assert success and then implemented the missing `MERGE` command logic in `userspace/phloem/src/executor.rs` to make the test pass. I also handled the `skip` parameter in `MERGE` execution.

---
*PR created automatically by Jules for task [16045237104209600213](https://jules.google.com/task/16045237104209600213) started by @dancxjo*