### PR TITLE
Add unit tests for phloem GQL ORDER BY parsing

### DIFF
--- a/userspace/phloem/src/gql.rs
+++ b/userspace/phloem/src/gql.rs
@@ -870,4 +870,51 @@ mod tests {
             panic!("Expected Match");
         }
     }
+
+    #[test]
+    fn test_parse_order_by() {
+        // Case 1: ORDER BY id(n) (default ASC)
+        let cmd = parse("MATCH (n) RETURN n ORDER BY id(n)").unwrap();
+        if let Command::Match { order_by, .. } = cmd {
+            if let Some(OrderBy::IdAsc(var)) = order_by {
+                assert_eq!(var, "n");
+            } else {
+                panic!("Expected OrderBy::IdAsc");
+            }
+        } else {
+            panic!("Expected Match");
+        }
+
+        // Case 2: ORDER BY id(n) ASC
+        let cmd = parse("MATCH (n) RETURN n ORDER BY id(n) ASC").unwrap();
+        if let Command::Match { order_by, .. } = cmd {
+            if let Some(OrderBy::IdAsc(var)) = order_by {
+                assert_eq!(var, "n");
+            } else {
+                panic!("Expected OrderBy::IdAsc");
+            }
+        } else {
+            panic!("Expected Match");
+        }
+
+        // Case 3: ORDER BY id(n) DESC
+        let cmd = parse("MATCH (n) RETURN n ORDER BY id(n) DESC").unwrap();
+        if let Command::Match { order_by, .. } = cmd {
+            if let Some(OrderBy::IdDesc(var)) = order_by {
+                assert_eq!(var, "n");
+            } else {
+                panic!("Expected OrderBy::IdDesc");
+            }
+        } else {
+            panic!("Expected Match");
+        }
+
+        // Case 4: Error cases
+        // ORDER with missing BY
+        assert!(parse("MATCH (n) RETURN n ORDER").is_err());
+        // ORDER BY missing variable/id
+        assert!(parse("MATCH (n) RETURN n ORDER BY n").is_err());
+        // ORDER BY invalid direction
+        assert!(parse("MATCH (n) RETURN n ORDER BY id(n) INVALID").is_err());
+    }
 }


### PR DESCRIPTION
This PR adds a comprehensive unit test for the `ORDER BY` clause parsing in the `phloem` GQL engine. The test ensures that the parser correctly handles ascending and descending order specifications, as well as various error conditions. This improves the robustness of the query parser and prevents regression in sorting logic.

---
*PR created automatically by Jules for task [17624663591316292447](https://jules.google.com/task/17624663591316292447) started by @dancxjo*