### PR TITLE
Fix wrongly passing MERGE test and enable MERGE command in Phloem

### DIFF
--- a/userspace/phloem/src/executor.rs
+++ b/userspace/phloem/src/executor.rs
@@ -115,13 +115,10 @@ impl<G: Graph> GraphExecutor<G> {
             Command::Quit => ExecutionResult::message("Bye."),
             Command::Schema => ExecutionResult::error("Schema not implemented."),
             Command::Merge {
-                pattern: _,
-                returns: _,
-                skip: _,
-            } => {
-                // TODO: Implement MERGE properly (for now it just MATCHes/CREATEs)
-                ExecutionResult::error("MERGE not fully implemented")
-            }
+                pattern,
+                returns,
+                skip,
+            } => self.execute_merge(pattern, returns, skip),
             Command::Match {
                 pattern,
                 where_clause,
@@ -151,6 +148,7 @@ impl<G: Graph> GraphExecutor<G> {
         &mut self,
         pattern: Pattern,
         returns: Vec<ReturnExpression>,
+        skip: usize,
     ) -> ExecutionResult {
         match pattern {
             Pattern::Node(node_pat) => {
@@ -165,6 +163,10 @@ impl<G: Graph> GraphExecutor<G> {
                 if returns.is_empty() {
                     return ExecutionResult::success(&format!("ok: merged node (id:{})", id));
                 } else {
+                    if skip > 0 {
+                        let cols: Vec<String> = returns.iter().map(|r| r.to_string()).collect();
+                        return ExecutionResult::rows(cols, alloc::vec![]);
+                    }
                     return self.format_results_structured(&returns);
                 }
             }
@@ -209,6 +211,11 @@ impl<G: Graph> GraphExecutor<G> {
                                 src_id, rel, dst_id
                             ))
                         } else {
+                            if skip > 0 {
+                                let cols: Vec<String> =
+                                    returns.iter().map(|r| r.to_string()).collect();
+                                return ExecutionResult::rows(cols, alloc::vec![]);
+                            }
                             if let Some(_rv) = rel_var {
                                 // Bind the relationship if possible?
                                 // Actually we don't have a good way to bind "edge IDs" yet as they are just predicates.
@@ -846,18 +853,6 @@ impl<G: Graph> GraphExecutor<G> {
             }
         }
         ExecutionResult::rows(col_names, alloc::vec![row])
-    }
-
-    fn format_node(&self, id: u64) -> String {
-        let kind_id = match self.graph.get_kind(ThingId::from_u64(id)) {
-            Ok(k) => k.0,
-            Err(_) => return format!("(id:{})", id),
-        };
-
-        let kind_name = self
-            .resolve_symbol(kind_id as u32)
-            .unwrap_or_else(|| format!("{}", kind_id));
-        format!("(id:{} :{})", id, kind_name)
     }
 
     fn resolve_symbol(&self, id: u32) -> Option<String> {

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -1,9 +1,8 @@
 use crate::executor::{Graph, GraphExecutor};
-use crate::gql::{parse, Value};
+use crate::gql::parse;
 use abi::ids::HandleId;
 use alloc::collections::BTreeMap;
 use alloc::string::{String, ToString};
-use alloc::vec;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 use stem::abi::symbols::SymbolId;
@@ -423,8 +422,13 @@ mod tests {
         let mut ex = GraphExecutor::with_graph(&g);
         let cmd = parse("MERGE (n:Kind {key: 1}) RETURN count(n)").unwrap();
         let res = ex.execute(cmd);
-        // MERGE is not fully implemented, but should not panic
-        assert!(!res.success || res.success); // Either works or reports error
+        assert!(res.success, "MERGE command failed");
+        assert_eq!(res.rows.len(), 1, "Expected 1 row result");
+        if let crate::ResultValue::Number(n) = res.rows[0][0] {
+            assert_eq!(n, 1, "Expected count(n) to be 1");
+        } else {
+            panic!("Expected Number result");
+        }
     }
 
     // ===== Parser-level tests for unsupported features =====


### PR DESCRIPTION
- **userspace/phloem/src/executor.rs**:
    - Updated `execute` to handle `Command::Merge` by calling `execute_merge`.
    - Updated `execute_merge` signature to accept `skip`.
    - Added logic to `execute_merge` to return empty rows if `skip > 0`.
    - Removed unused `format_node` method.
- **userspace/phloem/src/query_tests.rs**:
    - Modified `test_merge_node` to assert success and verify the result count is 1.
    - Removed unused imports (`Value`, `alloc::vec`).

---
*PR created automatically by Jules for task [15195396131437739789](https://jules.google.com/task/15195396131437739789) started by @dancxjo*