### PR TITLE
Fix phloem tokenizer to handle standard escape sequences

### DIFF
--- a/userspace/phloem/src/gql.rs
+++ b/userspace/phloem/src/gql.rs
@@ -185,7 +185,15 @@ fn tokenize(input: &str) -> Result<Vec<Token>, String> {
                     if nc == '\\' {
                         chars.next();
                         if let Some(ec) = chars.next() {
-                            s.push(ec);
+                            match ec {
+                                'n' => s.push('\n'),
+                                'r' => s.push('\r'),
+                                't' => s.push('\t'),
+                                '0' => s.push('\0'),
+                                '\\' => s.push('\\'),
+                                '"' => s.push('"'),
+                                _ => s.push(ec),
+                            }
                         }
                     } else if nc == '"' {
                         chars.next(); // skip closing
@@ -840,9 +848,25 @@ mod tests {
         if let Token::String(s) = &tokens[0] {
             assert_eq!(s, "hello world");
         }
-        // Note: our current tokenize doesn't actually handle backslash escapes based on view_file
-        // Let's check that.
     }
+
+    #[test]
+    fn test_tokenize_escapes() {
+        let tokens = tokenize("\"line\\nbreak\"").unwrap();
+        if let Token::String(s) = &tokens[0] {
+            assert_eq!(s, "line\nbreak");
+        } else {
+            panic!("Expected string token");
+        }
+
+        let tokens = tokenize("\"tab\\tcharacter\"").unwrap();
+        if let Token::String(s) = &tokens[0] {
+            assert_eq!(s, "tab\tcharacter");
+        } else {
+            panic!("Expected string token");
+        }
+    }
+
     #[test]
     fn test_parse_match_anonymous_edge() {
         let cmd = parse("MATCH ()-[e]->() RETURN e").unwrap();


### PR DESCRIPTION
Fixes a bug where the `phloem` tokenizer failed to correctly parse standard escape sequences in string literals. Added tests to verify the fix.

---
*PR created automatically by Jules for task [10095213367667304777](https://jules.google.com/task/10095213367667304777) started by @dancxjo*