### PR TITLE
Add unit test for COUNT in WHERE clause to phloem GQL parser

### DIFF
--- a/userspace/phloem/src/gql.rs
+++ b/userspace/phloem/src/gql.rs
@@ -946,4 +946,27 @@ mod tests {
         // ORDER BY invalid direction
         assert!(parse("MATCH (n) RETURN n ORDER BY id(n) INVALID").is_err());
     }
+
+    #[test]
+    fn test_parse_where_count_edges() {
+        let cmd = parse("MATCH (n) WHERE COUNT((n)-[]->()) = 5 RETURN n").unwrap();
+        if let Command::Match { where_clause, .. } = cmd {
+            if let Some(Expression::Eq(left, right)) = where_clause {
+                if let Expression::CountEdges(var) = *left {
+                    assert_eq!(var, "n");
+                } else {
+                    panic!("Expected CountEdges on left side");
+                }
+                if let Expression::Value(Value::Number(n)) = *right {
+                    assert_eq!(n, 5);
+                } else {
+                    panic!("Expected Number on right side");
+                }
+            } else {
+                panic!("Expected Eq expression");
+            }
+        } else {
+            panic!("Expected Match command");
+        }
+    }
 }


### PR DESCRIPTION
Added a unit test to `userspace/phloem/src/gql.rs` to verify that `COUNT` expressions in `WHERE` clauses are parsed correctly. This ensures that the parser properly handles `Expression::CountEdges` when used in a `WHERE` condition.

---
*PR created automatically by Jules for task [2391449559469243541](https://jules.google.com/task/2391449559469243541) started by @dancxjo*