### PR TITLE
Add unit test for phloem MERGE command

### DIFF
--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -534,4 +534,34 @@ mod tests {
             panic!("Expected Node ID");
         }
     }
+
+    #[test]
+    fn test_merge_existing_node() {
+        // MERGE (n:proc.Process {name: 12345}) RETURN n
+        // This should match the existing node 1 created in setup_mock
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+        let cmd = parse("MERGE (n:proc.Process {name: 12345}) RETURN n").unwrap();
+        let res = ex.execute(cmd);
+
+        assert!(res.success, "MERGE command failed");
+        assert_eq!(res.rows.len(), 1, "Expected 1 row result");
+
+        // It should be the existing node 1
+        if let crate::ResultValue::Node(id) = res.rows[0][0] {
+            assert_eq!(id, 1, "Expected to merge with existing node 1");
+        } else {
+            panic!("Expected Node result");
+        }
+
+        // Verify no new node was created (total count of proc.Process should be 2)
+        let cmd_count = parse("MATCH (n:proc.Process) RETURN count(n)").unwrap();
+        let res_count = ex.execute(cmd_count);
+        assert!(res_count.success);
+        if let crate::ResultValue::Number(n) = res_count.rows[0][0] {
+            assert_eq!(n, 2, "Expected still only 2 proc.Process nodes");
+        } else {
+            panic!("Expected Number result for count");
+        }
+    }
 }


### PR DESCRIPTION
This change adds a new unit test `test_merge_existing_node` to the `phloem` query tests. The test ensures that the `MERGE` GQL command behaves correctly by matching an existing node instead of creating a new one when a node with the specified kind and properties already exists. This validates the idempotency of `MERGE` operations in the graph database executor.

I used the `setup_mock` helper which creates a graph with known nodes (specifically a `proc.Process` node with `name: 12345`) and asserted that `MERGE (n:proc.Process {name: 12345})` returns the existing node ID and does not increase the node count.

---
*PR created automatically by Jules for task [75932056549362904](https://jules.google.com/task/75932056549362904) started by @dancxjo*