### PR TITLE
Fix phloem ID lookup optimization to verify node existence

### DIFF
--- a/userspace/phloem/src/executor.rs
+++ b/userspace/phloem/src/executor.rs
@@ -273,6 +273,7 @@ impl<G: Graph> GraphExecutor<G> {
 
                         if let Some(id) = target_id {
                             // Verify kind and other props
+                            // NOTE: We must check existence even if kind is None!
                             let matches_kind = match &node_pat.kind {
                                 Some(k) => match self.graph.get_kind(ThingId::from_u64(id)) {
                                     Ok(kind_id) => {
@@ -283,7 +284,7 @@ impl<G: Graph> GraphExecutor<G> {
                                     }
                                     Err(_) => false,
                                 },
-                                None => true,
+                                None => self.graph.get_kind(ThingId::from_u64(id)).is_ok(),
                             };
 
                             if matches_kind && self.matches_props(id, &node_pat.props) {

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -344,15 +344,14 @@ mod tests {
     #[test]
     fn test_lookup_nonexistent() {
         // MATCH (n) WHERE id(n) = 9999 RETURN n
-        // NOTE: The ID lookup optimization directly uses the ID without checking existence.
-        // This is by design - the graph treats all IDs as valid (lazy lookup).
+        // NOTE: The ID lookup optimization now checks existence.
         let g = setup_mock();
         let mut ex = GraphExecutor::with_graph(&g);
         let cmd = parse("MATCH (n) WHERE id(n) = 9999 RETURN n").unwrap();
         let res = ex.execute(cmd);
         assert!(res.success);
-        // The executor returns the ID regardless of existence (optimization behavior)
-        // This is acceptable - real usage validates nodes via kind/property checks
+        // Should find no rows because the node does not exist
+        assert!(res.rows.is_empty());
     }
 
     // ===== 3) Edges and neighborhood traversal =====


### PR DESCRIPTION
Fixes a bug where `MATCH (n) WHERE id(n) = ...` returned a result even if the node did not exist.
The fix ensures that node existence is verified before returning the node.
The corresponding test case `test_lookup_nonexistent` is updated to assert correct behavior.

---
*PR created automatically by Jules for task [12724361689133427578](https://jules.google.com/task/12724361689133427578) started by @dancxjo*