### PR TITLE
Add unit test for exact edge count in phloem WHERE clause

### DIFF
--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -342,6 +342,30 @@ mod tests {
     }
 
     #[test]
+    fn test_where_count_edges_exact() {
+        // MATCH (n) WHERE count((n)-[]->()) = 2 RETURN n
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+        let cmd = parse("MATCH (n) WHERE count((n)-[]->()) = 2 RETURN n").unwrap();
+        let res = ex.execute(cmd);
+        assert!(res.success);
+
+        // In our mock:
+        // Node 1 has CHILD(2), PARENT(3) -> 2 edges
+        // Node 3 has OWNS(1), OWNS(2) -> 2 edges
+        // We expect exactly these two nodes
+
+        let mut ids = Vec::new();
+        for row in res.rows {
+            if let crate::ResultValue::Node(id) = row[0] {
+                ids.push(id);
+            }
+        }
+        ids.sort();
+        assert_eq!(ids, vec![1, 3]);
+    }
+
+    #[test]
     fn test_lookup_nonexistent() {
         // MATCH (n) WHERE id(n) = 9999 RETURN n
         // NOTE: The ID lookup optimization directly uses the ID without checking existence.


### PR DESCRIPTION
Added a thoughtful unit test `test_where_count_edges_exact` to `userspace/phloem/src/query_tests.rs`.
This test validates the `count` aggregate function within a `WHERE` clause, specifically checking for an exact count of 2 outgoing edges.
This confirms the correctness of the graph query engine's counting logic beyond simple existence checks (0 vs >0).

---
*PR created automatically by Jules for task [11136101569632204063](https://jules.google.com/task/11136101569632204063) started by @dancxjo*