### PR TITLE
Fix phloem executor to validate node existence on ID lookup

### DIFF
--- a/userspace/phloem/src/executor.rs
+++ b/userspace/phloem/src/executor.rs
@@ -283,7 +283,10 @@ impl<G: Graph> GraphExecutor<G> {
                                     }
                                     Err(_) => false,
                                 },
-                                None => true,
+                                None => match self.graph.get_kind(ThingId::from_u64(id)) {
+                                    Ok(_) => true,
+                                    Err(_) => false,
+                                },
                             };
 
                             if matches_kind && self.matches_props(id, &node_pat.props) {

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -344,15 +344,14 @@ mod tests {
     #[test]
     fn test_lookup_nonexistent() {
         // MATCH (n) WHERE id(n) = 9999 RETURN n
-        // NOTE: The ID lookup optimization directly uses the ID without checking existence.
-        // This is by design - the graph treats all IDs as valid (lazy lookup).
+        // NOTE: The ID lookup optimization verifies existence to prevent phantom nodes.
         let g = setup_mock();
         let mut ex = GraphExecutor::with_graph(&g);
         let cmd = parse("MATCH (n) WHERE id(n) = 9999 RETURN n").unwrap();
         let res = ex.execute(cmd);
         assert!(res.success);
-        // The executor returns the ID regardless of existence (optimization behavior)
-        // This is acceptable - real usage validates nodes via kind/property checks
+        // The executor should return an empty result set for non-existent nodes
+        assert!(res.rows.is_empty(), "Expected empty result for non-existent node");
     }
 
     // ===== 3) Edges and neighborhood traversal =====


### PR DESCRIPTION
Fixes an issue where `MATCH (n) WHERE id(n) = 9999` would return a phantom node if the node did not exist. The executor now verifies the node's existence before returning it. The corresponding test `test_lookup_nonexistent` has been updated to assert an empty result set instead of a success with a phantom node.

---
*PR created automatically by Jules for task [6183666273703317155](https://jules.google.com/task/6183666273703317155) started by @dancxjo*