### PR TITLE
Add unit test for GQL COUNT expression parsing

### DIFF
--- a/userspace/phloem/src/gql.rs
+++ b/userspace/phloem/src/gql.rs
@@ -946,4 +946,28 @@ mod tests {
         // ORDER BY invalid direction
         assert!(parse("MATCH (n) RETURN n ORDER BY id(n) INVALID").is_err());
     }
+
+    #[test]
+    fn test_parse_count_edges_expression() {
+        let cmd = parse("MATCH (n) WHERE count((n)-[]->()) = 0 RETURN n").unwrap();
+        if let Command::Match { where_clause, .. } = cmd {
+            if let Some(Expression::Eq(left, right)) = where_clause {
+                if let Expression::CountEdges(var) = *left {
+                    assert_eq!(var, "n");
+                } else {
+                    panic!("Expected CountEdges on LHS, got {:?}", left);
+                }
+
+                if let Expression::Value(Value::Number(n)) = *right {
+                    assert_eq!(n, 0);
+                } else {
+                    panic!("Expected Number(0) on RHS, got {:?}", right);
+                }
+            } else {
+                panic!("Expected Eq expression in WHERE clause");
+            }
+        } else {
+            panic!("Expected Match command");
+        }
+    }
 }


### PR DESCRIPTION
Added a unit test to verify the parsing of GQL `COUNT` expressions involving edge patterns.
The test `test_parse_count_edges_expression` in `userspace/phloem/src/gql.rs` parses a query with `WHERE count((n)-[]->()) = 0` and asserts the correct AST structure.

---
*PR created automatically by Jules for task [7737451412239058268](https://jules.google.com/task/7737451412239058268) started by @dancxjo*