### PR TITLE
Fix phloem ID lookup returning phantom nodes

### DIFF
--- a/userspace/phloem/src/executor.rs
+++ b/userspace/phloem/src/executor.rs
@@ -283,7 +283,10 @@ impl<G: Graph> GraphExecutor<G> {
                                     }
                                     Err(_) => false,
                                 },
-                                None => true,
+                                None => match self.graph.get_kind(ThingId::from_u64(id)) {
+                                    Ok(_) => true,
+                                    Err(_) => false,
+                                },
                             };
 
                             if matches_kind && self.matches_props(id, &node_pat.props) {

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -344,15 +344,13 @@ mod tests {
     #[test]
     fn test_lookup_nonexistent() {
         // MATCH (n) WHERE id(n) = 9999 RETURN n
-        // NOTE: The ID lookup optimization directly uses the ID without checking existence.
-        // This is by design - the graph treats all IDs as valid (lazy lookup).
         let g = setup_mock();
         let mut ex = GraphExecutor::with_graph(&g);
         let cmd = parse("MATCH (n) WHERE id(n) = 9999 RETURN n").unwrap();
         let res = ex.execute(cmd);
         assert!(res.success);
-        // The executor returns the ID regardless of existence (optimization behavior)
-        // This is acceptable - real usage validates nodes via kind/property checks
+        // Should find NO nodes because ID 9999 does not exist
+        assert!(res.rows.is_empty(), "Expected empty result for non-existent node");
     }
 
     // ===== 3) Edges and neighborhood traversal =====


### PR DESCRIPTION
Fixes a bug where `MATCH (n) WHERE id(n) = ...` would return a result even if the node did not exist.
Updated `userspace/phloem/src/executor.rs` to validate node existence.
Updated `userspace/phloem/src/query_tests.rs` to assert correct behavior.

---
*PR created automatically by Jules for task [6519154236663192528](https://jules.google.com/task/6519154236663192528) started by @dancxjo*