### PR TITLE
Support inline node creation in GQL MERGE edges

### DIFF
--- a/docs/behavior/README.md
+++ b/docs/behavior/README.md
@@ -7,6 +7,9 @@ Behavior-driven development test results organized by target architecture.
 | Architecture | Status | Results |
 |-------------|--------|--------|
 | x86_64 | ❌ Failed | [📄 View Results](./x86_64/README.md) |
+| aarch64 | ❌ Failed | [📄 View Results](./aarch64/README.md) |
+| riscv64 | ❌ Failed | [📄 View Results](./riscv64/README.md) |
+| loongarch64 | ❌ Failed | [📄 View Results](./loongarch64/README.md) |
 
 ---
 

--- a/docs/behavior/features/idea_management.feature
+++ b/docs/behavior/features/idea_management.feature
@@ -1,0 +1,29 @@
+Feature: Idea Management
+
+  As a creative user
+  I want to record and organize my ideas in the system graph
+  So that I can develop them later
+
+  Scenario: Creating and Linking Ideas
+    Given the machine is running
+    And the anther server is ready
+
+    # Create the entire structure in one go
+    # We use a unique name to avoid conflicts if test runs multiple times (though graph state resets usually)
+    When I execute the GQL query "MERGE (p:Project {name: \"ThingOS Next\"})-[:CONTAINS]->(i:Idea {title: \"Graph Filesystem\", status: \"Draft\"}) RETURN p"
+    Then the response status should be 200
+
+    # Verify Project exists
+    When I execute the GQL query "MATCH (p:Project {name: \"ThingOS Next\"}) RETURN p"
+    Then the response status should be 200
+    And the response body should contain "ThingOS Next"
+
+    # Verify Idea exists
+    When I execute the GQL query "MATCH (i:Idea {title: \"Graph Filesystem\"}) RETURN i"
+    Then the response status should be 200
+    And the response body should contain "Graph Filesystem"
+
+    # Verify Link
+    When I execute the GQL query "MATCH (p:Project)-[:CONTAINS]->(i:Idea) RETURN i"
+    Then the response status should be 200
+    And the response body should contain "Graph Filesystem"

--- a/userspace/phloem/src/executor.rs
+++ b/userspace/phloem/src/executor.rs
@@ -176,22 +176,31 @@ impl<G: Graph> GraphExecutor<G> {
                 rel_kind,
                 dst,
             } => {
-                let src_id = match src.var.as_ref().and_then(|v| self.bindings.get(v)) {
-                    Some(&id) => id,
-                    None => {
-                        return ExecutionResult::error(&format!(
-                            "variable '{:?}' not bound",
-                            src.var
-                        ))
+                let src_id = if let Some(&id) = src.var.as_ref().and_then(|v| self.bindings.get(v)) {
+                    id
+                } else {
+                    match self.ensure_node(&src) {
+                        Ok(id) => {
+                            if let Some(var) = &src.var {
+                                self.bindings.insert(var.clone(), id);
+                            }
+                            id
+                        }
+                        Err(e) => return ExecutionResult::error(&e),
                     }
                 };
-                let dst_id = match dst.var.as_ref().and_then(|v| self.bindings.get(v)) {
-                    Some(&id) => id,
-                    None => {
-                        return ExecutionResult::error(&format!(
-                            "variable '{:?}' not bound",
-                            dst.var
-                        ))
+
+                let dst_id = if let Some(&id) = dst.var.as_ref().and_then(|v| self.bindings.get(v)) {
+                    id
+                } else {
+                    match self.ensure_node(&dst) {
+                        Ok(id) => {
+                            if let Some(var) = &dst.var {
+                                self.bindings.insert(var.clone(), id);
+                            }
+                            id
+                        }
+                        Err(e) => return ExecutionResult::error(&e),
                     }
                 };
 

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -534,4 +534,22 @@ mod tests {
             panic!("Expected Node ID");
         }
     }
+
+    #[test]
+    fn test_merge_edge_inline_creation() {
+        // MERGE (p:Project {name: "P1"})-[:CONTAINS]->(i:Idea {title: "I1"}) RETURN p
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+        let cmd = parse("MERGE (p:Project {name: \"P1\"})-[:CONTAINS]->(i:Idea {title: \"I1\"}) RETURN p").unwrap();
+        let res = ex.execute(cmd);
+        assert!(res.success, "MERGE command failed: {}", res.message);
+        assert_eq!(res.rows.len(), 1, "Expected 1 row result");
+
+        // Use another query to verify existence and link
+        // MATCH (p:Project {name: "P1"})-[:CONTAINS]->(i:Idea {title: "I1"}) RETURN i
+        let cmd2 = parse("MATCH (p:Project {name: \"P1\"})-[:CONTAINS]->(i:Idea {title: \"I1\"}) RETURN i").unwrap();
+        let res2 = ex.execute(cmd2);
+        assert!(res2.success, "Verification MATCH failed");
+        assert_eq!(res2.rows.len(), 1, "Expected to find the created pattern");
+    }
 }


### PR DESCRIPTION
This change enables inline node creation in GQL `MERGE` statements when using edge patterns. Previously, `MERGE (a)-[:REL]->(b)` required `a` and `b` to be bound variables. Now, if they are unbound node patterns (e.g., `(a:Kind {prop: val})`), the executor will lazily create or match them before creating the edge. This aligns with standard Cypher-like behavior for `MERGE` and simplifies graph creation queries.

Verification:
- Added `docs/behavior/features/idea_management.feature`.
- Added unit test `test_merge_edge_inline_creation` in `phloem` crate.
- Ran `cargo test -p phloem` successfully.


---
*PR created automatically by Jules for task [14529113067608819174](https://jules.google.com/task/14529113067608819174) started by @dancxjo*