### PR TITLE
Fix Phloem MATCH by ID returning non-existent nodes

### DIFF
--- a/userspace/phloem/src/executor.rs
+++ b/userspace/phloem/src/executor.rs
@@ -283,7 +283,10 @@ impl<G: Graph> GraphExecutor<G> {
                                     }
                                     Err(_) => false,
                                 },
-                                None => true,
+                                None => match self.graph.get_kind(ThingId::from_u64(id)) {
+                                    Ok(_) => true,
+                                    Err(_) => false,
+                                },
                             };
 
                             if matches_kind && self.matches_props(id, &node_pat.props) {

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -344,15 +344,13 @@ mod tests {
     #[test]
     fn test_lookup_nonexistent() {
         // MATCH (n) WHERE id(n) = 9999 RETURN n
-        // NOTE: The ID lookup optimization directly uses the ID without checking existence.
-        // This is by design - the graph treats all IDs as valid (lazy lookup).
         let g = setup_mock();
         let mut ex = GraphExecutor::with_graph(&g);
         let cmd = parse("MATCH (n) WHERE id(n) = 9999 RETURN n").unwrap();
         let res = ex.execute(cmd);
         assert!(res.success);
-        // The executor returns the ID regardless of existence (optimization behavior)
-        // This is acceptable - real usage validates nodes via kind/property checks
+        // The executor should verify existence even with direct ID lookup
+        assert!(res.rows.is_empty(), "Expected no rows for non-existent node ID");
     }
 
     // ===== 3) Edges and neighborhood traversal =====


### PR DESCRIPTION
Fixes an issue where `MATCH` queries filtering by ID would return non-existent nodes if no label was specified. Added an existence check to the optimization path and updated the relevant test case.

---
*PR created automatically by Jules for task [11741344512260433265](https://jules.google.com/task/11741344512260433265) started by @dancxjo*