### PR TITLE
Phloem MERGE inline node creation test and fix

### DIFF
--- a/userspace/phloem/src/executor.rs
+++ b/userspace/phloem/src/executor.rs
@@ -178,21 +178,37 @@ impl<G: Graph> GraphExecutor<G> {
             } => {
                 let src_id = match src.var.as_ref().and_then(|v| self.bindings.get(v)) {
                     Some(&id) => id,
-                    None => {
-                        return ExecutionResult::error(&format!(
-                            "variable '{:?}' not bound",
-                            src.var
-                        ))
-                    }
+                    None => match self.ensure_node(&src) {
+                        Ok(id) => {
+                            if let Some(var) = &src.var {
+                                self.bindings.insert(var.clone(), id);
+                            }
+                            id
+                        }
+                        Err(e) => {
+                            return ExecutionResult::error(&format!(
+                                "variable '{:?}' not bound and ensure_node failed: {}",
+                                src.var, e
+                            ))
+                        }
+                    },
                 };
                 let dst_id = match dst.var.as_ref().and_then(|v| self.bindings.get(v)) {
                     Some(&id) => id,
-                    None => {
-                        return ExecutionResult::error(&format!(
-                            "variable '{:?}' not bound",
-                            dst.var
-                        ))
-                    }
+                    None => match self.ensure_node(&dst) {
+                        Ok(id) => {
+                            if let Some(var) = &dst.var {
+                                self.bindings.insert(var.clone(), id);
+                            }
+                            id
+                        }
+                        Err(e) => {
+                            return ExecutionResult::error(&format!(
+                                "variable '{:?}' not bound and ensure_node failed: {}",
+                                dst.var, e
+                            ))
+                        }
+                    },
                 };
 
                 let rel_kind_str = rel_kind

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -617,4 +617,34 @@ mod tests {
             panic!("Expected Number result for count");
         }
     }
+
+    #[test]
+    fn test_merge_edge_inline() {
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+
+        // 1. Merge two new nodes with an edge between them
+        let cmd1 = parse("MERGE (u:User {name: \"Alice\"})-[:KNOWS]->(v:User {name: \"Bob\"}) RETURN u, v").unwrap();
+        let res1 = ex.execute(cmd1);
+
+        // This is expected to fail initially until the executor is updated
+        assert!(res1.success, "Inline MERGE failed: {:?}", res1.rows);
+        assert_eq!(res1.rows.len(), 1);
+
+        let u_id = if let crate::ResultValue::Node(id) = res1.rows[0][0] { id } else { panic!("Expected Node ID for u") };
+        let v_id = if let crate::ResultValue::Node(id) = res1.rows[0][1] { id } else { panic!("Expected Node ID for v") };
+
+        assert_ne!(u_id, v_id);
+
+        // 2. Run the same command again (idempotence)
+        let cmd2 = parse("MERGE (u:User {name: \"Alice\"})-[:KNOWS]->(v:User {name: \"Bob\"}) RETURN u, v").unwrap();
+        let res2 = ex.execute(cmd2);
+        assert!(res2.success);
+
+        let u_id_2 = if let crate::ResultValue::Node(id) = res2.rows[0][0] { id } else { panic!("Expected Node ID for u") };
+        let v_id_2 = if let crate::ResultValue::Node(id) = res2.rows[0][1] { id } else { panic!("Expected Node ID for v") };
+
+        assert_eq!(u_id, u_id_2);
+        assert_eq!(v_id, v_id_2);
+    }
 }


### PR DESCRIPTION
Added a new unit test for `MERGE` with inline node definitions and fixed the `phloem` executor to support this feature by lazily ensuring nodes exist when binding edge patterns.

---
*PR created automatically by Jules for task [8186190047774875493](https://jules.google.com/task/8186190047774875493) started by @dancxjo*