### PR TITLE
Fix phloem executor to support MERGE with inline node definitions

### DIFF
--- a/userspace/phloem/src/executor.rs
+++ b/userspace/phloem/src/executor.rs
@@ -176,22 +176,31 @@ impl<G: Graph> GraphExecutor<G> {
                 rel_kind,
                 dst,
             } => {
-                let src_id = match src.var.as_ref().and_then(|v| self.bindings.get(v)) {
-                    Some(&id) => id,
-                    None => {
-                        return ExecutionResult::error(&format!(
-                            "variable '{:?}' not bound",
-                            src.var
-                        ))
+                let src_id = if let Some(id) = src.var.as_ref().and_then(|v| self.bindings.get(v)) {
+                    *id
+                } else {
+                    match self.ensure_node(&src) {
+                        Ok(id) => {
+                            if let Some(var) = &src.var {
+                                self.bindings.insert(var.clone(), id);
+                            }
+                            id
+                        }
+                        Err(e) => return ExecutionResult::error(&e),
                     }
                 };
-                let dst_id = match dst.var.as_ref().and_then(|v| self.bindings.get(v)) {
-                    Some(&id) => id,
-                    None => {
-                        return ExecutionResult::error(&format!(
-                            "variable '{:?}' not bound",
-                            dst.var
-                        ))
+
+                let dst_id = if let Some(id) = dst.var.as_ref().and_then(|v| self.bindings.get(v)) {
+                    *id
+                } else {
+                    match self.ensure_node(&dst) {
+                        Ok(id) => {
+                            if let Some(var) = &dst.var {
+                                self.bindings.insert(var.clone(), id);
+                            }
+                            id
+                        }
+                        Err(e) => return ExecutionResult::error(&e),
                     }
                 };
 

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -617,4 +617,18 @@ mod tests {
             panic!("Expected Number result for count");
         }
     }
+
+    #[test]
+    fn test_merge_edge_inline_nodes() {
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+
+        // MERGE (a:Kind {key: 100})-[:REL]->(b:Kind {key: 101})
+        // This should create 'a', 'b', and the edge 'REL'.
+        let cmd = parse("MERGE (a:Kind {key: 100})-[:REL]->(b:Kind {key: 101}) RETURN a, b").unwrap();
+        let res = ex.execute(cmd);
+
+        assert!(res.success, "MERGE edge with inline nodes failed: {}", res.message);
+        assert_eq!(res.rows.len(), 1);
+    }
 }


### PR DESCRIPTION
The `GraphExecutor`'s `execute_merge` method previously returned an error
if the source or destination variables in a `MERGE` edge pattern (e.g.,
`MERGE (a)-[:R]->(b)`) were not already bound. This prevented the common
pattern of defining nodes inline within a relationship merge.

This change updates `execute_merge` to:
1. Check if the source/destination variable is bound.
2. If not bound, attempt to lazily resolve (find or create) the node using
   `ensure_node`.
3. If successful, bind the variable (if present) to the resolved node ID.
4. Proceed with `ensure_edge`.

This enables queries like `MERGE (a:Kind {key: 1})-[:REL]->(b:Kind {key: 2})`
to work as expected, aligning with standard Cypher behavior for inline nodes.

A regression test `test_merge_edge_inline_nodes` has been added to
`userspace/phloem/src/query_tests.rs`.

---
*PR created automatically by Jules for task [3945151837872341101](https://jules.google.com/task/3945151837872341101) started by @dancxjo*