### PR TITLE
Ensure graphics system launches by falling back to fake display

### DIFF
--- a/userspace/bloom/src/main.rs
+++ b/userspace/bloom/src/main.rs
@@ -588,6 +588,7 @@ fn main(arg: usize) -> ! {
 
         d_presenter
     } else {
+        stem::warn!("[bloom] WARNING: No display driver found! Using NullPresenter (headless mode). Screen will be black.");
         PresenterImpl::Null(present::NullPresenter)
     };
 

--- a/userspace/sprout/src/pipelines.rs
+++ b/userspace/sprout/src/pipelines.rs
@@ -215,6 +215,17 @@ pub fn setup_display_pipeline(tasks: &mut Vec<ManagedTask>) -> Option<DisplayHan
         }
     }
 
+    // Fallback to display_fake if no other display found (ensures Bloom launches)
+    if driver_name.is_none() {
+        warn!("SPROUT: No display device found! Using display_fake (headless mode)");
+        display_width = 1024;
+        display_height = 768;
+        display_stride = 1024 * 4;
+        display_format = 1; // BGRA8888
+        driver_name = Some("/display_fake");
+        backend_name = "Fake";
+    }
+
     let driver_name = match driver_name {
         Some(name) => name,
         None => {


### PR DESCRIPTION
This change addresses the issue where the graphics system would fail to launch or appear broken (black screen) if no hardware display device was detected.

*   Modified `userspace/sprout/src/pipelines.rs`: Added fallback logic to use `display_fake` if no other display driver is found.
*   Modified `userspace/bloom/src/main.rs`: Added warning log when using `NullPresenter`.

This ensures the UI services launch successfully even in headless environments, allowing for better debugging and stability.

---
*PR created automatically by Jules for task [3258637588379173446](https://jules.google.com/task/3258637588379173446) started by @dancxjo*