### PR TITLE
Add unit test for MERGE with parameters in Phloem

### DIFF
--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -631,4 +631,47 @@ mod tests {
         assert!(res.success, "MERGE edge with inline nodes failed: {}", res.message);
         assert_eq!(res.rows.len(), 1);
     }
+
+    #[test]
+    fn test_merge_with_params() {
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+
+        // Parameter for property value
+        ex.set_parameter("p_key".to_string(), crate::gql::Value::Number(999));
+
+        // MERGE using the parameter
+        let cmd = parse("MERGE (n:Kind {key: $p_key}) RETURN n").unwrap();
+        let res = ex.execute(cmd);
+
+        assert!(res.success, "MERGE with params failed: {}", res.message);
+        assert_eq!(res.rows.len(), 1);
+
+        let id = if let crate::ResultValue::Node(id) = res.rows[0][0] {
+            id
+        } else {
+            panic!("Expected Node ID");
+        };
+
+        // Verify the node was created with the correct property value by querying it back
+        // We use the literal value here to ensure the parameter was correctly resolved during MERGE
+        let cmd_check = parse("MATCH (n:Kind {key: 999}) RETURN n").unwrap();
+        let res_check = ex.execute(cmd_check);
+
+        assert!(res_check.success);
+        assert_eq!(
+            res_check.rows.len(),
+            1,
+            "Should find the node with property key=999"
+        );
+
+        if let crate::ResultValue::Node(id_check) = res_check.rows[0][0] {
+            assert_eq!(
+                id, id_check,
+                "The found node should be the same as the merged one"
+            );
+        } else {
+            panic!("Expected Node ID");
+        }
+    }
 }


### PR DESCRIPTION
Added a new unit test `test_merge_with_params` to `userspace/phloem/src/query_tests.rs` to verify that `MERGE` operations correctly utilize query parameters. The test ensures that a node created via `MERGE` with a parameter has the correct property value and can be retrieved by a subsequent `MATCH` query. This enhances the test coverage for parameterized queries in the Phloem graph database engine.

---
*PR created automatically by Jules for task [9525644611389700168](https://jules.google.com/task/9525644611389700168) started by @dancxjo*