### PR TITLE
fix(stem): resolve doctest compilation errors in drawlist and viewport

### DIFF
--- a/stem/src/petals/drawlist.rs
+++ b/stem/src/petals/drawlist.rs
@@ -17,9 +17,10 @@ use alloc::vec::Vec;
 ///
 /// # Example
 /// ```no_run
-/// use stem::petals::DrawList;
+/// use stem::petals::drawlist::DrawList;
 /// use stem::thing::ThingId;
 /// use abi::drawlist::{DrawListBuilder, FillRule, PathVerb, PointF};
+/// use abi::ids::HandleId;
 ///
 /// let window_id = ThingId::from_u64(42);
 /// let mut dl = DrawList::new(window_id);

--- a/stem/src/petals/viewport/mod.rs
+++ b/stem/src/petals/viewport/mod.rs
@@ -6,7 +6,7 @@
 //! # Example
 //!
 //! ```
-//! use stem::viewport::{Viewport, PanZoomController, ViewportConstraints};
+//! use stem::petals::viewport::{Viewport, PanZoomController, ViewportConstraints};
 //!
 //! let mut controller = PanZoomController::new(
 //!     Viewport::new(800.0, 600.0),
@@ -20,6 +20,8 @@
 //! controller.pan_by_screen(10.0, 5.0); // Pan right and down
 //!
 //! // Convert screen coordinates to world coordinates for hit testing
+//! let click_x = 400.0;
+//! let click_y = 300.0;
 //! let world_pos = controller.viewport.screen_to_world(click_x, click_y);
 //! ```
 


### PR DESCRIPTION
- Imported the `abi::ids::HandleId` trait and updated the doctest in `drawlist.rs` to correctly instantiate `ThingId` from integer values by using `from_u64`.
- Corrected incorrect imports and provided previously missing mock parameters in `viewport/mod.rs` to allow the example code to compile properly.
- All doctests under `cargo test -p stem --doc` now successfully pass.

---
*PR created automatically by Jules for task [9843508121582190217](https://jules.google.com/task/9843508121582190217) started by @dancxjo*