### PR TITLE
Add unit test for count() with no matches in phloem

### DIFF
--- a/kernel/src/root/handlers/watch.rs
+++ b/kernel/src/root/handlers/watch.rs
@@ -308,7 +308,7 @@ mod tests {
         let reply = Arc::new(ReplyCell::new());
         let msg = RootMsg {
             op,
-            reply: reply.clone(),
+            reply: Some(reply.clone()),
         };
 
         // Call handler
@@ -355,7 +355,7 @@ mod tests {
         let reply = Arc::new(ReplyCell::new());
         let msg = RootMsg {
             op,
-            reply: reply.clone(),
+            reply: Some(reply.clone()),
         };
 
         let (status, _written) = handle_watch_next(&mut graph, &msg, watch_id);
@@ -424,7 +424,7 @@ mod tests {
         let reply = Arc::new(ReplyCell::new());
         let msg = RootMsg {
             op,
-            reply: reply.clone(),
+            reply: Some(reply.clone()),
         };
 
         let (status, written) = handle_watch_next(&mut graph, &msg, watch_id);
@@ -476,7 +476,7 @@ mod tests {
             out_len: 0,
         };
         let reply = Arc::new(ReplyCell::new());
-        let msg = RootMsg { op, reply };
+        let msg = RootMsg { op, reply: Some(reply) };
 
         let (status, _written) = handle_watch_next(&mut graph, &msg, watch_id);
 

--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -692,4 +692,16 @@ mod tests {
             panic!("Expected Node ID");
         }
     }
+
+    #[test]
+    fn test_count_with_no_matches() {
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+        let cmd = parse("MATCH (n:NonExistent) RETURN count(n)").unwrap();
+        let res = ex.execute(cmd);
+        assert!(res.success);
+        assert_eq!(res.rows.len(), 1);
+        assert_eq!(res.rows[0].len(), 1);
+        assert!(matches!(res.rows[0][0], crate::ResultValue::Number(0)));
+    }
 }


### PR DESCRIPTION
Adds a useful unit test to the graph executor verifying that the `count()` aggregation function correctly returns `0` when there are no nodes matching the query pattern, instead of returning an empty result set or error. Also fixes a broken test in `kernel/src/root/handlers/watch.rs`.

---
*PR created automatically by Jules for task [4488827286915320486](https://jules.google.com/task/4488827286915320486) started by @dancxjo*