### PR TITLE
test: add unit test for multiple inline properties

### DIFF
--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -442,6 +442,33 @@ mod tests {
     }
 
     #[test]
+    fn test_match_multiple_inline_properties() {
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+
+        // MATCH (n {name: 12345, state: 100}) RETURN n
+        // In setup_mock, node 1 has name=12345 and state=100
+        let cmd = parse("MATCH (n {name: 12345, state: 100}) RETURN n").unwrap();
+        let res = ex.execute(cmd);
+        assert!(res.success);
+        assert_eq!(res.rows.len(), 1);
+
+        // Make sure it's node 1
+        if let crate::ResultValue::Node(id) = res.rows[0][0] {
+            assert_eq!(id, 1);
+        } else {
+            panic!("Expected Node ID");
+        }
+
+        // Now test conflicting properties
+        let cmd2 = parse("MATCH (n {name: 12345, state: 999}) RETURN n").unwrap();
+        let res2 = ex.execute(cmd2);
+        assert!(res2.success);
+        // Node 1 has state 100, not 999, so it shouldn't match
+        assert!(res2.rows.is_empty());
+    }
+
+    #[test]
     fn test_count_edge_matches() {
         // MATCH (a)-[]->(b) RETURN count(b) LIMIT 200
         // This should return the count of edges, not "count() not supported" message


### PR DESCRIPTION
Adds a new unit test `test_match_multiple_inline_properties` to `userspace/phloem/src/query_tests.rs` to verify the GQL parser and executor support matching nodes by multiple inline properties simultaneously. 

The test creates a mock graph, searches for a node with two correctly specified properties, ensuring it returns exactly one matching result. It then executes a query for the same node with one conflicting property, asserting that it returns no results.

---
*PR created automatically by Jules for task [18274985004865481490](https://jules.google.com/task/18274985004865481490) started by @dancxjo*