### PR TITLE
Add unit test for PixelFormat properties

### DIFF
--- a/abi/src/pixel.rs
+++ b/abi/src/pixel.rs
@@ -216,6 +216,21 @@ mod tests {
     }
 
     #[test]
+    fn test_pixel_format_properties() {
+        assert_eq!(PixelFormat::Bgra8888.bytes_per_pixel(), 4);
+        assert!(PixelFormat::Bgra8888.has_alpha());
+
+        assert_eq!(PixelFormat::Bgrx8888.bytes_per_pixel(), 4);
+        assert!(!PixelFormat::Bgrx8888.has_alpha());
+
+        assert_eq!(PixelFormat::Rgb565.bytes_per_pixel(), 2);
+        assert!(!PixelFormat::Rgb565.has_alpha());
+
+        assert_eq!(PixelFormat::Unknown.bytes_per_pixel(), 0);
+        assert!(!PixelFormat::Unknown.has_alpha());
+    }
+
+    #[test]
     fn test_premultiply() {
         // Opaque - no change
         let opaque = Color::from_rgba(100, 150, 200, 255);

--- a/kernel/src/root/handlers/watch.rs
+++ b/kernel/src/root/handlers/watch.rs
@@ -308,7 +308,7 @@ mod tests {
         let reply = Arc::new(ReplyCell::new());
         let msg = RootMsg {
             op,
-            reply: reply.clone(),
+            reply: Some(reply.clone()),
         };
 
         // Call handler
@@ -355,7 +355,7 @@ mod tests {
         let reply = Arc::new(ReplyCell::new());
         let msg = RootMsg {
             op,
-            reply: reply.clone(),
+            reply: Some(reply.clone()),
         };
 
         let (status, _written) = handle_watch_next(&mut graph, &msg, watch_id);
@@ -424,7 +424,7 @@ mod tests {
         let reply = Arc::new(ReplyCell::new());
         let msg = RootMsg {
             op,
-            reply: reply.clone(),
+            reply: Some(reply.clone()),
         };
 
         let (status, written) = handle_watch_next(&mut graph, &msg, watch_id);
@@ -476,7 +476,7 @@ mod tests {
             out_len: 0,
         };
         let reply = Arc::new(ReplyCell::new());
-        let msg = RootMsg { op, reply };
+        let msg = RootMsg { op, reply: Some(reply) };
 
         let (status, _written) = handle_watch_next(&mut graph, &msg, watch_id);
 


### PR DESCRIPTION
This commit introduces a new unit test in `abi/src/pixel.rs` which verifies the expected return values of `PixelFormat::bytes_per_pixel()` and `PixelFormat::has_alpha()` for the variants `Bgra8888`, `Bgrx8888`, `Rgb565`, and `Unknown`. It also includes a necessary fix in `kernel/src/root/handlers/watch.rs` to correctly initialize the `RootMsg` `reply` field with an `Option` wrapping.

---
*PR created automatically by Jules for task [7159428557114323460](https://jules.google.com/task/7159428557114323460) started by @dancxjo*