### PR TITLE
Fix failing tests and compilation errors in userspace/bloom

### DIFF
--- a/stem/src/simd/mod.rs
+++ b/stem/src/simd/mod.rs
@@ -4,7 +4,7 @@
 
 #[cfg(target_arch = "aarch64")]
 mod neon;
-mod scalar;
+pub mod scalar;
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 mod x86;
 

--- a/userspace/bloom/src/damage.rs
+++ b/userspace/bloom/src/damage.rs
@@ -186,6 +186,7 @@ impl Damage {
         }
 
         // Try to merge with existing rects
+        let mut merged = false;
         for i in 0..self.count {
             if self.rects[i].touches_or_overlaps(clipped) {
                 self.rects[i] = self.rects[i].union(clipped);
@@ -194,21 +195,32 @@ impl Damage {
                     self.causes[i] = cause;
                     self.sources[i] = source;
                 }
-                // After merge, try to consolidate further
-                self.consolidate();
-                return;
+                merged = true;
+                break;
             }
         }
 
-        // No merge possible, add as new rect
-        if self.count < MAX_RECTS {
-            self.rects[self.count] = clipped;
-            self.causes[self.count] = cause;
-            self.sources[self.count] = source;
-            self.count += 1;
+        if merged {
+            // After merge, try to consolidate further
+            self.consolidate();
+            // Check if the merged rects cover >25% screen
+            for i in 0..self.count {
+                if self.rects[i].area() * 4 > self.bounds.area() {
+                    self.collapse_to_full_with_cause(self.causes[i], self.sources[i]);
+                    return;
+                }
+            }
         } else {
-            // Exceeded MAX_RECTS, collapse to full-frame
-            self.collapse_to_full_with_cause(cause, source);
+            // No merge possible, add as new rect
+            if self.count < MAX_RECTS {
+                self.rects[self.count] = clipped;
+                self.causes[self.count] = cause;
+                self.sources[self.count] = source;
+                self.count += 1;
+            } else {
+                // Exceeded MAX_RECTS, collapse to full-frame
+                self.collapse_to_full_with_cause(cause, source);
+            }
         }
     }
 
@@ -629,13 +641,18 @@ mod tests {
         let mut d = Damage::empty(bounds);
 
         // Add MAX_RECTS separate rects
+        // Make sure none of these overlap, and none of them will cause collapse due to the 25% area rule
         for i in 0..MAX_RECTS {
-            d.add_rect(Rect::new((i * 100) as i32, 0, 10, 10));
+            // Need to place them such that they don't overlap when consolidated.
+            // Also need to be careful with y to not overlap
+            let x = (i % 8) as i32 * 100;
+            let y = (i / 8) as i32 * 100;
+            d.add_rect(Rect::new(x, y, 10, 10));
         }
         assert!(!d.is_full);
 
-        // One more should collapse
-        d.add_rect(Rect::new(900, 0, 10, 10));
+        // One more should collapse (make sure it doesn't overlap to trigger the overflow)
+        d.add_rect(Rect::new(900, 900, 10, 10));
         assert!(d.is_full);
     }
 
@@ -665,7 +682,7 @@ mod tests {
         t.begin_frame(100, 100);
 
         let rect = Rect::new(10, 10, 20, 20);
-        let source = Some(ThingId::from_u64(42));
+        let source = Some(ThingId([42; 16]));
         t.note_bbox_with_cause(rect, DamageCause::GeometryChanged, source);
 
         let d = t.end_frame();
@@ -680,7 +697,7 @@ mod tests {
         let mut t = DamageTracker::new();
         t.begin_frame(100, 100);
 
-        let source = Some(ThingId::from_u64(99));
+        let source = Some(ThingId([99; 16]));
         t.mark_full_with_cause(DamageCause::ForceFull, source);
 
         let d = t.end_frame();
@@ -709,8 +726,8 @@ mod tests {
         let bounds = Rect::full(100, 100);
         let mut d = Damage::empty(bounds);
 
-        let source1 = Some(ThingId::from_u64(10));
-        let source2 = Some(ThingId::from_u64(20));
+        let source1 = Some(ThingId([10; 16]));
+        let source2 = Some(ThingId([20; 16]));
 
         d.add_rect_with_cause(
             Rect::new(0, 0, 10, 10),

--- a/userspace/bloom/src/render_state.rs
+++ b/userspace/bloom/src/render_state.rs
@@ -515,7 +515,9 @@ mod tests {
 
     #[test]
     fn evicts_when_over_budget() {
-        let mut state = RenderState::with_cache_limit(32);
+        // Cache limit: 16 bytes. image_of_size(2, 2) takes 2 * 2 * 4 = 16 bytes.
+        // Inserting two images will require eviction.
+        let mut state = RenderState::with_cache_limit(16);
         let key_a = RasterKey::Text {
             w: 2,
             h: 2,

--- a/userspace/bloom/src/svg/walk.rs
+++ b/userspace/bloom/src/svg/walk.rs
@@ -140,7 +140,7 @@ mod tests {
     impl GraphApply for TestGraph {
         fn create_node(&mut self, _kind: &str) -> Result<ThingId, XmlIngestError> {
             self.nodes += 1;
-            Ok(ThingId::from_u64(self.nodes))
+            Ok(ThingId([self.nodes as u8; 16]))
         }
 
         fn link(&mut self, src: ThingId, rel: &str, dst: ThingId) -> Result<(), XmlIngestError> {

--- a/userspace/bloom/src/ui/layout.rs
+++ b/userspace/bloom/src/ui/layout.rs
@@ -718,7 +718,7 @@ mod tests {
             root_id,
             UiNodeSnapshot {
                 id: root_id,
-                kind: UiNodeKind::Root,
+                kind: UiNodeKind::Crown,
                 props: root_props,
                 strings: BTreeMap::new(),
                 children: vec![child_id],

--- a/userspace/bloom/src/vir/examples.rs
+++ b/userspace/bloom/src/vir/examples.rs
@@ -137,7 +137,7 @@ mod tests {
         let doc = example_filled_rect(10.0, 10.0, 100.0, 50.0, 255, 0, 0);
         assert_eq!(doc.elements.len(), 1);
 
-        let drawlist = render_vir_default(&doc);
+        let mut drawlist = render_vir_default(&doc);
         assert!(!drawlist.commands().is_empty());
     }
 
@@ -146,7 +146,7 @@ mod tests {
         let doc = example_filled_circle(50.0, 50.0, 25.0, 0, 255, 0);
         assert_eq!(doc.elements.len(), 1);
 
-        let drawlist = render_vir_default(&doc);
+        let mut drawlist = render_vir_default(&doc);
         assert!(!drawlist.commands().is_empty());
     }
 
@@ -155,7 +155,7 @@ mod tests {
         let doc = example_stroked_line(0.0, 0.0, 100.0, 100.0, 2.0, 0, 0, 255);
         assert_eq!(doc.elements.len(), 1);
 
-        let drawlist = render_vir_default(&doc);
+        let mut drawlist = render_vir_default(&doc);
         assert!(!drawlist.commands().is_empty());
     }
 
@@ -163,8 +163,8 @@ mod tests {
     fn test_quality_comparison() {
         let doc = example_bezier_path();
 
-        let default_list = render_vir_default(&doc);
-        let hq_list = render_vir_high_quality(&doc);
+        let mut default_list = render_vir_default(&doc);
+        let mut hq_list = render_vir_high_quality(&doc);
 
         // High quality should potentially have more commands due to finer tessellation
         assert!(!default_list.commands().is_empty());

--- a/userspace/bloom/src/vir/mod.rs
+++ b/userspace/bloom/src/vir/mod.rs
@@ -75,39 +75,3 @@ impl Default for VirDocument {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_create_empty_document() {
-        let doc = VirDocument::new();
-        assert_eq!(doc.elements.len(), 0);
-        assert!(doc.width.is_none());
-        assert!(doc.height.is_none());
-        assert!(doc.view_box.is_none());
-    }
-
-    #[test]
-    fn test_create_simple_rect() {
-        let mut path = VirPath::new();
-        path.move_to(0.0, 0.0);
-        path.line_to(100.0, 0.0);
-        path.line_to(100.0, 100.0);
-        path.line_to(0.0, 100.0);
-        path.close();
-
-        let elem = VirElement {
-            path: Arc::new(path),
-            fill: Some(FillStyle {
-                paint: Paint::Solid(VirColor::rgb(255, 0, 0)),
-                rule: FillRule::NonZero,
-            }),
-            stroke: None,
-            transform: VirTransform::identity(),
-            opacity: 1.0,
-        };
-
-        assert_eq!(elem.path.segments.len(), 5);
-    }
-}

--- a/userspace/bloom/src/vir/render.rs
+++ b/userspace/bloom/src/vir/render.rs
@@ -150,7 +150,7 @@ mod tests {
         });
 
         let config = TessellateConfig::default();
-        let list = vir_to_drawlist(&doc, &config);
+        let mut list = vir_to_drawlist(&doc, &config);
 
         assert!(!list.commands().is_empty());
     }

--- a/userspace/bloom/src/vir/shapes.rs
+++ b/userspace/bloom/src/vir/shapes.rs
@@ -163,8 +163,8 @@ mod tests {
     #[test]
     fn test_circle() {
         let path = circle_to_path(50.0, 50.0, 25.0);
-        // Circle uses 4 cubic beziers + close
-        assert_eq!(path.segments.len(), 5);
+        // Circle uses 4 cubic beziers + move to + close
+        assert_eq!(path.segments.len(), 6);
 
         match path.segments[0] {
             VirSegment::MoveTo(p) => {

--- a/userspace/bloom/src/vir/tests.rs
+++ b/userspace/bloom/src/vir/tests.rs
@@ -7,6 +7,38 @@ mod tests {
     use alloc::sync::Arc;
 
     #[test]
+    fn test_create_empty_document() {
+        let doc = VirDocument::new();
+        assert_eq!(doc.elements.len(), 0);
+        assert!(doc.width.is_none());
+        assert!(doc.height.is_none());
+        assert!(doc.view_box.is_none());
+    }
+
+    #[test]
+    fn test_create_simple_rect() {
+        let mut path = VirPath::new();
+        path.move_to(0.0, 0.0);
+        path.line_to(100.0, 0.0);
+        path.line_to(100.0, 100.0);
+        path.line_to(0.0, 100.0);
+        path.close();
+
+        let elem = VirElement {
+            path: Arc::new(path),
+            fill: Some(FillStyle {
+                paint: Paint::Solid(VirColor::rgb(255, 0, 0)),
+                rule: FillRule::NonZero,
+            }),
+            stroke: None,
+            transform: VirTransform::identity(),
+            opacity: 1.0,
+        };
+
+        assert_eq!(elem.path.segments.len(), 5);
+    }
+
+    #[test]
     fn test_simple_rect_pipeline() {
         // Create a simple rectangle path
         let mut path = VirPath::new();
@@ -34,7 +66,7 @@ mod tests {
 
         // Convert to DrawList
         let config = TessellateConfig::default();
-        let drawlist = vir_to_drawlist(&doc, &config);
+        let mut drawlist = vir_to_drawlist(&doc, &config);
 
         // Should have at least one command
         assert!(!drawlist.commands().is_empty());
@@ -60,7 +92,7 @@ mod tests {
         doc.elements.push(element);
 
         let config = TessellateConfig::default();
-        let drawlist = vir_to_drawlist(&doc, &config);
+        let mut drawlist = vir_to_drawlist(&doc, &config);
 
         assert!(!drawlist.commands().is_empty());
     }
@@ -90,7 +122,7 @@ mod tests {
         doc.elements.push(element);
 
         let config = TessellateConfig::default();
-        let drawlist = vir_to_drawlist(&doc, &config);
+        let mut drawlist = vir_to_drawlist(&doc, &config);
 
         assert!(!drawlist.commands().is_empty());
     }


### PR DESCRIPTION
This submission resolves three failing/broken test scenarios in the `userspace/bloom` package alongside several active compilation warnings and API drift issues.

- **vir/shapes**: Re-aligned the `test_circle` logic as the SVG expansion algorithm naturally generates 6 path segments (1 move, 4 curves, 1 close), not 5.
- **render_state**: Adjusted the arbitrary capacity budget in the eviction test. The cache was large enough to hold the generated test assets without triggering the tested path.
- **damage**: Fixed the damage tracker bug where merging rectangles did not evaluate the >25% area threshold properly, and subsequently corrected the poorly formulated `test_damage_collapse_on_overflow` which caused all test rectangles to merge immediately instead of hitting the `MAX_RECTS` threshold.
- Addressed multiple instances of missing API signatures (`ThingId::from_u64`), out-of-date enums (`UiNodeKind::Root` -> `Crown`), and strict borrow-checker errors around `mut`.

---
*PR created automatically by Jules for task [5042831772038378470](https://jules.google.com/task/5042831772038378470) started by @dancxjo*