### PR TITLE
test(phloem): add lookup by id kind mismatch test

### DIFF
--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -393,6 +393,19 @@ mod tests {
         assert!(res.rows.is_empty());
     }
 
+    #[test]
+    fn test_lookup_by_id_kind_mismatch() {
+        // MATCH (n:proc.Thread) WHERE id(n) = 1 RETURN n
+        // Node 1 is a proc.Process, so it should not match the kind proc.Thread
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+        let cmd = parse("MATCH (n:proc.Thread) WHERE id(n) = 1 RETURN n").unwrap();
+        let res = ex.execute(cmd);
+        assert!(res.success);
+        // Should find no rows because the node kind does not match
+        assert!(res.rows.is_empty());
+    }
+
     // ===== 3) Edges and neighborhood traversal =====
 
     #[test]


### PR DESCRIPTION
Added a unit test to verify that finding a node by ID with an incorrect kind correctly returns an empty result instead of matching.

---
*PR created automatically by Jules for task [16678742940248062098](https://jules.google.com/task/16678742940248062098) started by @dancxjo*