### PR TITLE
test(phloem): verify correct counting behavior on empty matches

### DIFF
--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -567,6 +567,23 @@ mod tests {
     }
 
     #[test]
+    fn test_count_match_with_no_results() {
+        // MATCH (n:NonExistent) RETURN count(n)
+        // Ensure it returns a number (0) rather than empty results.
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+        let cmd = parse("MATCH (n:NonExistent) RETURN count(n)").unwrap();
+        let res = ex.execute(cmd);
+        assert!(res.success);
+        assert_eq!(res.rows.len(), 1);
+        if let crate::ResultValue::Number(n) = res.rows[0][0] {
+            assert_eq!(n, 0);
+        } else {
+            panic!("Expected Number result");
+        }
+    }
+
+    #[test]
     fn test_order_desc() {
         // MATCH (n) RETURN n ORDER BY id(n) DESC LIMIT 2
         let g = setup_mock();


### PR DESCRIPTION
Adds a unit test to verify that `GraphExecutor` handles aggregate functions on zero-result sets correctly, returning zero instead of an empty row.

---
*PR created automatically by Jules for task [5062336783182184593](https://jules.google.com/task/5062336783182184593) started by @dancxjo*