### PR TITLE
Fix `bloom` mutability tests and logic in `test_quality_comparison`

### DIFF
--- a/userspace/bloom/src/vir/examples.rs
+++ b/userspace/bloom/src/vir/examples.rs
@@ -137,7 +137,7 @@ mod tests {
         let doc = example_filled_rect(10.0, 10.0, 100.0, 50.0, 255, 0, 0);
         assert_eq!(doc.elements.len(), 1);
 
-        let drawlist = render_vir_default(&doc);
+        let mut drawlist = render_vir_default(&doc);
         assert!(!drawlist.commands().is_empty());
     }
 
@@ -146,7 +146,7 @@ mod tests {
         let doc = example_filled_circle(50.0, 50.0, 25.0, 0, 255, 0);
         assert_eq!(doc.elements.len(), 1);
 
-        let drawlist = render_vir_default(&doc);
+        let mut drawlist = render_vir_default(&doc);
         assert!(!drawlist.commands().is_empty());
     }
 
@@ -155,7 +155,7 @@ mod tests {
         let doc = example_stroked_line(0.0, 0.0, 100.0, 100.0, 2.0, 0, 0, 255);
         assert_eq!(doc.elements.len(), 1);
 
-        let drawlist = render_vir_default(&doc);
+        let mut drawlist = render_vir_default(&doc);
         assert!(!drawlist.commands().is_empty());
     }
 
@@ -163,11 +163,12 @@ mod tests {
     fn test_quality_comparison() {
         let doc = example_bezier_path();
 
-        let default_list = render_vir_default(&doc);
-        let hq_list = render_vir_high_quality(&doc);
+        let mut default_list = render_vir_default(&doc);
+        let mut hq_list = render_vir_high_quality(&doc);
 
         // High quality should potentially have more commands due to finer tessellation
         assert!(!default_list.commands().is_empty());
         assert!(!hq_list.commands().is_empty());
+        assert!(hq_list.commands().len() > default_list.commands().len());
     }
 }

--- a/userspace/bloom/src/vir/render.rs
+++ b/userspace/bloom/src/vir/render.rs
@@ -150,7 +150,7 @@ mod tests {
         });
 
         let config = TessellateConfig::default();
-        let list = vir_to_drawlist(&doc, &config);
+        let mut list = vir_to_drawlist(&doc, &config);
 
         assert!(!list.commands().is_empty());
     }

--- a/userspace/bloom/src/vir/tests.rs
+++ b/userspace/bloom/src/vir/tests.rs
@@ -34,7 +34,7 @@ mod tests {
 
         // Convert to DrawList
         let config = TessellateConfig::default();
-        let drawlist = vir_to_drawlist(&doc, &config);
+        let mut drawlist = vir_to_drawlist(&doc, &config);
 
         // Should have at least one command
         assert!(!drawlist.commands().is_empty());
@@ -60,7 +60,7 @@ mod tests {
         doc.elements.push(element);
 
         let config = TessellateConfig::default();
-        let drawlist = vir_to_drawlist(&doc, &config);
+        let mut drawlist = vir_to_drawlist(&doc, &config);
 
         assert!(!drawlist.commands().is_empty());
     }
@@ -90,7 +90,7 @@ mod tests {
         doc.elements.push(element);
 
         let config = TessellateConfig::default();
-        let drawlist = vir_to_drawlist(&doc, &config);
+        let mut drawlist = vir_to_drawlist(&doc, &config);
 
         assert!(!drawlist.commands().is_empty());
     }


### PR DESCRIPTION
The tests in `userspace/bloom/src/vir/examples.rs`, `render.rs`, and `tests.rs` failed to build since they didn't define their `DrawList` variables as mutable before calling `commands()` (which requires `&mut self`).

Additionally, the `test_quality_comparison` test incorrectly verified only that neither draw list was empty, instead of validating the commented intent: "High quality should potentially have more commands due to finer tessellation".

This commit:
- Updates `DrawList` variable instantiations in tests to be `mut`.
- Updates `test_quality_comparison` to assert that `hq_list.commands().len() > default_list.commands().len()`.

---
*PR created automatically by Jules for task [8071345744266882489](https://jules.google.com/task/8071345744266882489) started by @dancxjo*