### PR TITLE
Add phloem unit test for matching multiple properties

### DIFF
--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -692,4 +692,28 @@ mod tests {
             panic!("Expected Node ID");
         }
     }
+
+    #[test]
+    fn test_match_multiple_properties() {
+        let g = setup_mock();
+        // Node 1 has name: 12345, state: 100
+        let mut ex = GraphExecutor::with_graph(&g);
+
+        // Match with multiple matching properties
+        let cmd = parse("MATCH (n {name: 12345, state: 100}) RETURN n").unwrap();
+        let res = ex.execute(cmd);
+        assert!(res.success);
+        assert_eq!(res.rows.len(), 1);
+        if let crate::ResultValue::Node(id) = res.rows[0][0] {
+            assert_eq!(id, 1);
+        } else {
+            panic!("Expected Node ID");
+        }
+
+        // Match with one matching and one conflicting property
+        let cmd_conflict = parse("MATCH (n {name: 12345, state: 999}) RETURN n").unwrap();
+        let res_conflict = ex.execute(cmd_conflict);
+        assert!(res_conflict.success);
+        assert!(res_conflict.rows.is_empty(), "Should return empty if any property conflicts");
+    }
 }


### PR DESCRIPTION
I added a unit test (`test_match_multiple_properties`) in `userspace/phloem/src/query_tests.rs`. This test creates a graph with a node containing multiple properties (`name: 12345, state: 100`). It tests that matching using both these properties returns the node correctly. It also tests that matching with one correct and one conflicting property correctly returns an empty result set.

I have run the phloem test suite, and all 49 tests now pass successfully.

---
*PR created automatically by Jules for task [17854922057230603553](https://jules.google.com/task/17854922057230603553) started by @dancxjo*