### PR TITLE
Fix failing doc tests in `stem` crate

### DIFF
--- a/stem/src/petals/drawlist.rs
+++ b/stem/src/petals/drawlist.rs
@@ -20,6 +20,7 @@ use alloc::vec::Vec;
 /// use stem::petals::DrawList;
 /// use stem::thing::ThingId;
 /// use abi::drawlist::{DrawListBuilder, FillRule, PathVerb, PointF};
+/// use abi::ids::HandleId;
 ///
 /// let window_id = ThingId::from_u64(42);
 /// let mut dl = DrawList::new(window_id);

--- a/stem/src/petals/viewport/mod.rs
+++ b/stem/src/petals/viewport/mod.rs
@@ -6,7 +6,7 @@
 //! # Example
 //!
 //! ```
-//! use stem::viewport::{Viewport, PanZoomController, ViewportConstraints};
+//! use stem::petals::viewport::{Viewport, PanZoomController, ViewportConstraints};
 //!
 //! let mut controller = PanZoomController::new(
 //!     Viewport::new(800.0, 600.0),
@@ -20,6 +20,8 @@
 //! controller.pan_by_screen(10.0, 5.0); // Pan right and down
 //!
 //! // Convert screen coordinates to world coordinates for hit testing
+//! let click_x = 100.0;
+//! let click_y = 100.0;
 //! let world_pos = controller.viewport.screen_to_world(click_x, click_y);
 //! ```
 


### PR DESCRIPTION
The doc tests in the `stem` crate were failing due to missing trait imports and undeclared variables. I added the necessary `HandleId` import in `drawlist.rs` and fixed the `viewport` module doc test by adjusting the import path to `use stem::petals::viewport::{...};` and providing dummy initialization for `click_x` and `click_y` variables. I verified that running `cargo test -p stem` successfully compiles and passes the previously failing tests.

---
*PR created automatically by Jules for task [16897692677857045967](https://jules.google.com/task/16897692677857045967) started by @dancxjo*