### PR TITLE
Add test for matching nodes with multiple properties

### DIFF
--- a/userspace/phloem/src/query_tests.rs
+++ b/userspace/phloem/src/query_tests.rs
@@ -651,6 +651,16 @@ mod tests {
         assert!(!res.rows.is_empty(), "Expected edges from node 1, but got empty result. The executor likely confused property 'id' with internal Node ID.");
     }
     #[test]
+    fn test_multiple_properties_in_node_pattern() {
+        let g = setup_mock();
+        let mut ex = GraphExecutor::with_graph(&g);
+        let cmd = parse("MATCH (n:proc.Process {name: 12345, state: 100}) RETURN n").unwrap();
+        let res = ex.execute(cmd);
+        assert!(res.success);
+        assert_eq!(res.rows.len(), 1);
+    }
+
+    #[test]
     fn test_merge_with_params() {
         let g = setup_mock();
         let mut ex = GraphExecutor::with_graph(&g);


### PR DESCRIPTION
This PR adds a test `test_multiple_properties_in_node_pattern` to `userspace/phloem/src/query_tests.rs` to verify that the `MATCH` command properly parses and filters nodes with multiple inline properties.

---
*PR created automatically by Jules for task [8155770665699438665](https://jules.google.com/task/8155770665699438665) started by @dancxjo*