### PR TITLE
test(phloem): add unit test for parsing multiple node properties

### DIFF
--- a/userspace/phloem/src/gql.rs
+++ b/userspace/phloem/src/gql.rs
@@ -711,6 +711,43 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_match_multiple_props() {
+        let cmd = parse("MATCH (n {id: 1, type: \"user\", status: \"active\"}) RETURN n").unwrap();
+        if let Command::Match { pattern, .. } = cmd {
+            if let Pattern::Node(pat) = pattern {
+                assert_eq!(pat.var.as_deref(), Some("n"));
+                assert_eq!(pat.kind, None);
+                assert_eq!(pat.props.len(), 3);
+
+                assert_eq!(pat.props[0].0, "id");
+                if let Value::Number(n) = pat.props[0].1 {
+                    assert_eq!(n, 1);
+                } else {
+                    panic!("Wrong prop value type for id");
+                }
+
+                assert_eq!(pat.props[1].0, "type");
+                if let Value::String(ref s) = pat.props[1].1 {
+                    assert_eq!(s, "user");
+                } else {
+                    panic!("Wrong prop value type for type");
+                }
+
+                assert_eq!(pat.props[2].0, "status");
+                if let Value::String(ref s) = pat.props[2].1 {
+                    assert_eq!(s, "active");
+                } else {
+                    panic!("Wrong prop value type for status");
+                }
+            } else {
+                panic!("Expected Pattern::Node");
+            }
+        } else {
+            panic!("Expected Command::Match");
+        }
+    }
+
+    #[test]
     fn test_parse_match_kind_props() {
         let cmd = parse("MATCH (p:proc.Process {name: \"init\"}) RETURN p").unwrap();
         if let Command::Match { pattern, .. } = cmd {


### PR DESCRIPTION
Added a new unit test `test_parse_match_multiple_props` to `userspace/phloem/src/gql.rs`. This test ensures the GQL parser correctly processes `MATCH` commands that include multiple inline properties within a node pattern, verifying the AST correctly reflects the variable name, absence of a kind, and all properties with their correct types. All relevant tests passed.

---
*PR created automatically by Jules for task [16243544819769738166](https://jules.google.com/task/16243544819769738166) started by @dancxjo*