### PR TITLE
test(phloem): add unit test for multiple return expressions in gql parser

### DIFF
--- a/userspace/phloem/src/gql.rs
+++ b/userspace/phloem/src/gql.rs
@@ -969,4 +969,16 @@ mod tests {
             panic!("Expected Match command");
         }
     }
+
+    #[test]
+    fn test_parse_return_multiple_expressions() {
+        let cmd = parse("MATCH (n) RETURN count(n), n").unwrap();
+        if let Command::Match { returns, .. } = cmd {
+            assert_eq!(returns.len(), 2);
+            assert_eq!(returns[0], ReturnExpression::Count("n".to_string()));
+            assert_eq!(returns[1], ReturnExpression::Variable("n".to_string()));
+        } else {
+            panic!("Expected Match command");
+        }
+    }
 }


### PR DESCRIPTION
Add `test_parse_return_multiple_expressions` to `userspace/phloem/src/gql.rs` to verify that the GraphQL parser correctly parses multiple return expressions separated by commas, such as `RETURN count(n), n`.

---
*PR created automatically by Jules for task [15583859883856063361](https://jules.google.com/task/15583859883856063361) started by @dancxjo*