### PR TITLE
Add useful unit test for watch stream cursor modes

### DIFF
--- a/kernel/src/root/handlers/watch.rs
+++ b/kernel/src/root/handlers/watch.rs
@@ -211,9 +211,9 @@ pub fn handle_watch_next(graph: &mut Graph, msg: &crate::root::RootMsg, id: u64)
             core::ptr::copy_nonoverlapping(src, dst, payload.len());
         }
 
-    if let Some(reply) = msg.reply.as_ref() {
-        reply.p0.store(match_cursor, Ordering::Relaxed);
-    }
+        if let Some(reply) = msg.reply.as_ref() {
+            reply.p0.store(match_cursor, Ordering::Relaxed);
+        }
 
         if let Some(watch) = graph.global_watches.get_mut(&id) {
             watch.cursor_seq = match_cursor + 1;
@@ -271,6 +271,55 @@ mod tests {
     }
 
     #[test]
+    fn test_handle_watch_open_cursor_modes() {
+        let mut graph = Graph::new();
+        let mut interner = Interner::new();
+
+        // Push 3 commits so oldest=1, newest=3, next=4
+        graph.commit_history.push(1, vec![1], CommitSummary::default());
+        graph.commit_history.push(2, vec![2], CommitSummary::default());
+        graph.commit_history.push(3, vec![3], CommitSummary::default());
+
+        let filter = WatchFilter::default();
+
+        // 1. WATCH_START_LATEST should start at next_seq (which is 4)
+        let (_, watch_id_latest) = handle_watch_open(
+            &mut graph,
+            &mut interner,
+            0,
+            abi::types::WATCH_START_LATEST,
+            vec![],
+            filter.clone(),
+        );
+        let watch_latest = graph.global_watches.get(&watch_id_latest).unwrap();
+        assert_eq!(watch_latest.cursor_seq, 4, "LATEST should start at next sequence");
+
+        // 2. start_seq = 0 should start at oldest available (which is 1)
+        let (_, watch_id_zero) = handle_watch_open(
+            &mut graph,
+            &mut interner,
+            0,
+            0,
+            vec![],
+            filter.clone(),
+        );
+        let watch_zero = graph.global_watches.get(&watch_id_zero).unwrap();
+        assert_eq!(watch_zero.cursor_seq, 1, "0 should start at oldest available sequence");
+
+        // 3. Specific start_seq (e.g., 2) should start exactly there
+        let (_, watch_id_specific) = handle_watch_open(
+            &mut graph,
+            &mut interner,
+            0,
+            2,
+            vec![],
+            filter.clone(),
+        );
+        let watch_specific = graph.global_watches.get(&watch_id_specific).unwrap();
+        assert_eq!(watch_specific.cursor_seq, 2, "Specific sequence should start precisely there");
+    }
+
+    #[test]
     fn test_handle_watch_next_basic() {
         let mut graph = Graph::new();
         // Setup history with one commit (seq 1)
@@ -308,7 +357,7 @@ mod tests {
         let reply = Arc::new(ReplyCell::new());
         let msg = RootMsg {
             op,
-            reply: reply.clone(),
+            reply: Some(reply.clone()),
         };
 
         // Call handler
@@ -355,7 +404,7 @@ mod tests {
         let reply = Arc::new(ReplyCell::new());
         let msg = RootMsg {
             op,
-            reply: reply.clone(),
+            reply: Some(reply.clone()),
         };
 
         let (status, _written) = handle_watch_next(&mut graph, &msg, watch_id);
@@ -424,7 +473,7 @@ mod tests {
         let reply = Arc::new(ReplyCell::new());
         let msg = RootMsg {
             op,
-            reply: reply.clone(),
+            reply: Some(reply.clone()),
         };
 
         let (status, written) = handle_watch_next(&mut graph, &msg, watch_id);
@@ -476,7 +525,7 @@ mod tests {
             out_len: 0,
         };
         let reply = Arc::new(ReplyCell::new());
-        let msg = RootMsg { op, reply };
+        let msg = RootMsg { op, reply: Some(reply) };
 
         let (status, _written) = handle_watch_next(&mut graph, &msg, watch_id);
 

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1196,6 +1196,7 @@ mod tests {
 
     #[test]
     fn test_priority_aging_boost() {
+        unsafe { crate::init_runtime(&MockRuntime) };
         init_test_env();
         static RUNTIME: MockRuntime = MockRuntime;
         // Test that tasks waiting too long get priority boost when scheduling
@@ -1281,6 +1282,7 @@ mod tests {
 
     #[test]
     fn test_reset_priority_aging_on_schedule() {
+        unsafe { crate::init_runtime(&MockRuntime) };
         init_test_env();
         static RUNTIME: MockRuntime = MockRuntime;
         // Test that enqueued_at_tick resets when task is preempted/yields
@@ -1364,7 +1366,9 @@ mod tests {
 
     #[test]
     fn test_wake_preempts_lower_priority() {
+        unsafe { crate::init_runtime(&MockRuntime) };
         init_test_env();
+        crate::task::registry::init::<MockRuntime>();
         use core::sync::atomic::Ordering;
 
         static RUNTIME: MockRuntime = MockRuntime;
@@ -1469,7 +1473,9 @@ mod tests {
 
     #[test]
     fn test_sorted_insertion() {
+        unsafe { crate::init_runtime(&MockRuntime) };
         init_test_env();
+        crate::task::registry::init::<MockRuntime>();
         static RUNTIME: MockRuntime = MockRuntime;
         let mut sched = types::Scheduler::<MockRuntime>::new();
         sched.state.per_cpu.push(crate::sched::state::PerCpu::new());
@@ -1526,7 +1532,9 @@ mod tests {
 
     #[test]
     fn test_block_and_wake_state_transitions() {
+        unsafe { crate::init_runtime(&MockRuntime) };
         init_test_env();
+        crate::task::registry::init::<MockRuntime>();
         static RUNTIME: MockRuntime = MockRuntime;
         let mut sched = types::Scheduler::<MockRuntime>::new();
         sched.state.per_cpu.push(crate::sched::state::PerCpu::new());


### PR DESCRIPTION
Adds a new thoughtful unit test in `kernel/src/root/handlers/watch.rs` to verify that `handle_watch_open` properly resolves cursor sequence modes including `WATCH_START_LATEST`. It also fixes existing compiler bugs in `watch.rs` tests to ensure the unit tests compile and run properly.

---
*PR created automatically by Jules for task [9673065359867171975](https://jules.google.com/task/9673065359867171975) started by @dancxjo*