### PR TITLE
test(abi): add ABI size and alignment validation for device structs

### DIFF
--- a/abi/src/device.rs
+++ b/abi/src/device.rs
@@ -68,3 +68,33 @@ pub struct RtcTime {
     pub weekday: u8, // 0-6
     pub flags: u8,   // Status flags
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn test_device_abi_sizes() {
+        assert_eq!(size_of::<DeviceKind>(), 4);
+        assert_eq!(align_of::<DeviceKind>(), 4);
+
+        assert_eq!(size_of::<DeviceHandle>(), 4);
+        assert_eq!(align_of::<DeviceHandle>(), 4);
+
+        assert_eq!(size_of::<RootCaps>(), 0);
+        assert_eq!(align_of::<RootCaps>(), 1);
+
+        assert_eq!(size_of::<DeviceCall>(), 40);
+        assert_eq!(align_of::<DeviceCall>(), 8);
+
+        assert_eq!(size_of::<PciEnableMsiRequest>(), 8);
+        assert_eq!(align_of::<PciEnableMsiRequest>(), 4);
+
+        assert_eq!(size_of::<PciEnableMsiResponse>(), 4);
+        assert_eq!(align_of::<PciEnableMsiResponse>(), 1);
+
+        assert_eq!(size_of::<RtcTime>(), 10);
+        assert_eq!(align_of::<RtcTime>(), 2);
+    }
+}


### PR DESCRIPTION
Adds a new unit test module to `abi/src/device.rs` that explicitly asserts `core::mem::size_of` and `core::mem::align_of` for cross-boundary ABI structures like `DeviceCall`, `DeviceKind`, and `RtcTime`. This ensures stable memory layouts are maintained across FFI and syscall boundaries within the OS.

---
*PR created automatically by Jules for task [18031340712130727821](https://jules.google.com/task/18031340712130727821) started by @dancxjo*