### PR TITLE
test(abi): add layout tests for device.rs types

### DIFF
--- a/abi/src/device.rs
+++ b/abi/src/device.rs
@@ -68,3 +68,30 @@ pub struct RtcTime {
     pub weekday: u8, // 0-6
     pub flags: u8,   // Status flags
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn test_device_abi_layouts() {
+        assert_eq!(size_of::<DeviceHandle>(), 4);
+        assert_eq!(align_of::<DeviceHandle>(), 4);
+
+        assert_eq!(size_of::<RootCaps>(), 0);
+        assert_eq!(align_of::<RootCaps>(), 1);
+
+        assert_eq!(size_of::<DeviceCall>(), 40);
+        assert_eq!(align_of::<DeviceCall>(), 8);
+
+        assert_eq!(size_of::<PciEnableMsiRequest>(), 8);
+        assert_eq!(align_of::<PciEnableMsiRequest>(), 4);
+
+        assert_eq!(size_of::<PciEnableMsiResponse>(), 4);
+        assert_eq!(align_of::<PciEnableMsiResponse>(), 1);
+
+        assert_eq!(size_of::<RtcTime>(), 10);
+        assert_eq!(align_of::<RtcTime>(), 2);
+    }
+}


### PR DESCRIPTION
This patch adds a simple but critical unit test to `abi/src/device.rs` to assert the exact size and alignment of its types. Because `abi` is used for FFI/syscall boundaries, ensuring these types do not accidentally change shape (due to compiler padding rules or type changes) is crucial.

---
*PR created automatically by Jules for task [12990031045593050437](https://jules.google.com/task/12990031045593050437) started by @dancxjo*