### PR TITLE
test: add layout assertions to abi devices

### DIFF
--- a/abi/src/device.rs
+++ b/abi/src/device.rs
@@ -68,3 +68,32 @@ pub struct RtcTime {
     pub weekday: u8, // 0-6
     pub flags: u8,   // Status flags
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_device_layout() {
+        assert_eq!(core::mem::size_of::<DeviceKind>(), 4);
+        assert_eq!(core::mem::align_of::<DeviceKind>(), 4);
+
+        assert_eq!(core::mem::size_of::<DeviceHandle>(), 4);
+        assert_eq!(core::mem::align_of::<DeviceHandle>(), 4);
+
+        assert_eq!(core::mem::size_of::<RootCaps>(), 0);
+        assert_eq!(core::mem::align_of::<RootCaps>(), 1);
+
+        assert_eq!(core::mem::size_of::<DeviceCall>(), 40);
+        assert_eq!(core::mem::align_of::<DeviceCall>(), 8);
+
+        assert_eq!(core::mem::size_of::<PciEnableMsiRequest>(), 8);
+        assert_eq!(core::mem::align_of::<PciEnableMsiRequest>(), 4);
+
+        assert_eq!(core::mem::size_of::<PciEnableMsiResponse>(), 4);
+        assert_eq!(core::mem::align_of::<PciEnableMsiResponse>(), 1);
+
+        assert_eq!(core::mem::size_of::<RtcTime>(), 10);
+        assert_eq!(core::mem::align_of::<RtcTime>(), 2);
+    }
+}


### PR DESCRIPTION
Adds tests verifying exact memory layouts in `abi/src/device.rs` to ensure ABI stability.

---
*PR created automatically by Jules for task [4788032162623635054](https://jules.google.com/task/4788032162623635054) started by @dancxjo*