### PR TITLE
test(irq): Fix `test_irq_lock_free_dispatch` test state leakage

### DIFF
--- a/kernel/src/irq/mod.rs
+++ b/kernel/src/irq/mod.rs
@@ -240,6 +240,8 @@ mod tests {
         assert_eq!(registry.try_wait(vector, 1), 1);
         assert_eq!(registry.try_wait(vector, 2), 1);
 
+        WAKE_COUNT.store(0, Ordering::Relaxed);
+
         registry.dispatch(vector);
         registry.dispatch(vector);
         assert_eq!(registry.try_wait(vector, 1), 2);

--- a/kernel/src/root/handlers/watch.rs
+++ b/kernel/src/root/handlers/watch.rs
@@ -308,7 +308,7 @@ mod tests {
         let reply = Arc::new(ReplyCell::new());
         let msg = RootMsg {
             op,
-            reply: reply.clone(),
+            reply: Some(reply.clone()),
         };
 
         // Call handler
@@ -355,7 +355,7 @@ mod tests {
         let reply = Arc::new(ReplyCell::new());
         let msg = RootMsg {
             op,
-            reply: reply.clone(),
+            reply: Some(reply.clone()),
         };
 
         let (status, _written) = handle_watch_next(&mut graph, &msg, watch_id);
@@ -424,7 +424,7 @@ mod tests {
         let reply = Arc::new(ReplyCell::new());
         let msg = RootMsg {
             op,
-            reply: reply.clone(),
+            reply: Some(reply.clone()),
         };
 
         let (status, written) = handle_watch_next(&mut graph, &msg, watch_id);
@@ -476,7 +476,7 @@ mod tests {
             out_len: 0,
         };
         let reply = Arc::new(ReplyCell::new());
-        let msg = RootMsg { op, reply };
+        let msg = RootMsg { op, reply: Some(reply) };
 
         let (status, _written) = handle_watch_next(&mut graph, &msg, watch_id);
 


### PR DESCRIPTION
The `test_irq_lock_free_dispatch` in `kernel/src/irq/mod.rs` was failing when running `cargo test -p kernel` due to the test asserting `WAKE_COUNT == 2`, when actually `WAKE_COUNT` could be 3 or more because it wasn't reset before checking the second dispatch case. This PR adds a `WAKE_COUNT.store(0, Ordering::Relaxed);` prior to checking the subsequent `dispatch` calls in the test, preserving the spirit of the test while ensuring it passes reliably.

---
*PR created automatically by Jules for task [7861245830797049213](https://jules.google.com/task/7861245830797049213) started by @dancxjo*