### PR TITLE
Fix broken test compilation due to ThingId API changes

### DIFF
--- a/userspace/disk_probe/src/main.rs
+++ b/userspace/disk_probe/src/main.rs
@@ -20,7 +20,7 @@ fn main(_arg: usize) -> ! {
     stem::sleep(core::time::Duration::from_millis(500));
 
     // Find all dev.storage.Disk Things
-    let mut disks = [ThingId(0); 8];
+    let mut disks = [ThingId([0; 16]); 8];
     let count = match thingsys::find("dev.storage.Disk", &mut disks) {
         Ok(c) => c,
         Err(e) => {
@@ -52,7 +52,7 @@ fn main(_arg: usize) -> ! {
 }
 
 fn probe_disk(disk_id: ThingId, index: usize) {
-    info!("DISK_PROBE: === Disk {} (Thing {}) ===", index, disk_id.0);
+    info!("DISK_PROBE: === Disk {} (Thing {:?}) ===", index, disk_id);
 
     // Get disk properties
     match thingsys::prop_get(disk_id, "sector_count") {

--- a/userspace/display_fake/src/main.rs
+++ b/userspace/display_fake/src/main.rs
@@ -6,7 +6,7 @@ use abi::driver_frame::FrameReader;
 use stem::abi::module_manifest::{ManifestHeader, ModuleKind, MANIFEST_MAGIC};
 use stem::info;
 use stem::syscall::{port_recv, port_send, PortHandle};
-use stem::thing::ThingId;
+use stem::thing::{ThingId, HandleId};
 
 #[unsafe(link_section = ".thing_manifest")]
 #[unsafe(no_mangle)]


### PR DESCRIPTION
Resolves test compilation errors caused by the recent changes to the `ThingId` type structure.

Changes made:
- In `userspace/disk_probe/src/main.rs`: `ThingId` is now initialized using a 16-byte array `[0; 16]` instead of a single integer. Formatting for `ThingId` has also been updated to use `Debug` (`{:?}`) instead of `Display` since `[u8; 16]` does not implement `Display`.
- In `userspace/display_fake/src/main.rs`: Imported the `HandleId` trait from `stem::thing::HandleId` which provides the `from_u64` method previously missing.

Compilation passes for all workspace members after applying the exclusions for targets with known issues.

---
*PR created automatically by Jules for task [7861245830797049213](https://jules.google.com/task/7861245830797049213) started by @dancxjo*